### PR TITLE
proto: fix typo inside result.proto

### DIFF
--- a/proto/result.proto
+++ b/proto/result.proto
@@ -38,7 +38,7 @@ message AttestationResult {
     string AppraisalPolicyID = 6 [json_name = "appraisal-policy-id"];
 
     // Extension
-    google.protobuf.Struct processed_evidence = 7 [json_name = "veraison-procesed-evidence"];
+    google.protobuf.Struct processed_evidence = 7 [json_name = "veraison-processed-evidence"];
 }
 
 // vim: set et sts=4 sw=4 ai:


### PR DESCRIPTION
Correct the spelling of the json_name "veraison-processed-evidence"
inside  AttestationResult message.

This addresses https://github.com/veraison/services/issues/6