### PR TITLE
getPolicy should return `ErrNoPolicy` when `o.Store.Get` fails

### DIFF
--- a/vts/policymanager/policymanager.go
+++ b/vts/policymanager/policymanager.go
@@ -67,7 +67,7 @@ func (o *PolicyManager) getPolicy(ev *proto.EvidenceContext) (*policy.Policy, er
 
 	vals, err := o.Store.Get(policyID)
 	if err != nil {
-		return nil, err
+		return nil, ErrNoPolicy
 	}
 
 	// TODO(setrofim): for now, assuming that there should be exactly one


### PR DESCRIPTION
This is a fix for #25 