### PR TITLE
Added a config file for the verification binary

### DIFF
--- a/verification/cmd/config.yaml
+++ b/verification/cmd/config.yaml
@@ -1,0 +1,4 @@
+vts-server:
+  addr: "dns:127.0.0.1:50051",
+listen-addr: "localhost:8080"
+

--- a/verification/cmd/main.go
+++ b/verification/cmd/main.go
@@ -10,22 +10,27 @@ import (
 	"github.com/veraison/services/vtsclient"
 )
 
-var (
-	ListenAddr  = "localhost:8080"
-	VerifierCfg = config.Store{
-		// placeholder, empty for now
-	}
-	VTSClientCfg = config.Store{
-		"vts-server.addr": "dns:127.0.0.1:50051",
-	}
-)
-
 func main() {
-	sessionManager := sessionmanager.NewSessionManagerTTLCache()
-	vtsClient := vtsclient.NewGRPC(VTSClientCfg)
-	verifier := verifier.New(VerifierCfg, vtsClient)
+	cfg := config.NewYAMLReader()
+
+	_, err := cfg.ReadFile("config.yaml")
+	if err != nil {
+		log.Fatalf("counfig.yaml could not be read.")
+	}
+
+	let vtsClientConfig = config.Store{
+		"vts-server.addr": cfg.MustGetStore("vts-server.addr"),
+	}
+
+	let verifierConfig = config.Store {
+		 // placeholder, empty for now
+	}
+
+		sessionManager := sessionmanager.NewSessionManagerTTLCache()
+	vtsClient := vtsclient.NewGRPC(vtsClientConfig)
+	verifier := verifier.New(verifierConfig, vtsClient)
 	apiHandler := api.NewHandler(sessionManager, verifier)
-	apiServer(apiHandler, ListenAddr)
+	apiServer(apiHandler, cfg.MustGetStore("listen-addr"))
 }
 
 func apiServer(apiHandler api.IHandler, listenAddr string) {


### PR DESCRIPTION
The configuration options for `verification/cmd/main.go` were hard-coded, which meant that anyone wanting to use the non-default configuration needed to fork the project. This PR is one way to add a configuration file for the binary, negating the need for a fork.