### PR TITLE
kvstore ErrKeyNotFound and associated fixes

### DIFF
--- a/kvstore/common.go
+++ b/kvstore/common.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 )
 
+var ErrKeyNotFound = errors.New("key not found")
+
 func sanitizeKV(key, val string) error {
 	if err := sanitizeK(key); err != nil {
 		return err

--- a/kvstore/ikvstore.go
+++ b/kvstore/ikvstore.go
@@ -4,11 +4,33 @@ package kvstore
 
 import "github.com/veraison/services/config"
 
+// IKVStore is the interface to a key-value store. Keys and values are both
+// strings. A key can be associated with multiple values.
 type IKVStore interface {
+	// Init initializes the store. The parameters of the config.Store are
+	// implementation-specific -- please see the documentation for the
+	// implementation you're using.
 	Init(cfg config.Store) error
+
+	// Close the store, shutting down the underlying connection (if one
+	// exists in the implementation), and disallowing any further
+	// operations.
 	Close() error
+
+	// Get returns a []string of values for the specified key. If the
+	// specified key is not in the store, a ErrKeyNotFound is returned.
 	Get(key string) ([]string, error)
+
+	// Set the specified key to the specified value, discarding any
+	// existing values.
 	Set(key, val string) error
+
+	// Del removes the specfied key from the store, discarding its
+	// associated values.
 	Del(key string) error
+
+	// Add the specified value to the specified key. If the key does
+	// not already exist, this behaves like Set. If the key exists, the
+	// specified val is appended to the existing value(s).
 	Add(key, val string) error
 }

--- a/kvstore/memory.go
+++ b/kvstore/memory.go
@@ -21,6 +21,8 @@ type Memory struct {
 	Data map[string][]string
 }
 
+// Init initializes the KVStore. There are no configuration options for this
+// implementation.
 func (o *Memory) Init(unused config.Store) error {
 	o.Data = make(map[string][]string)
 
@@ -46,7 +48,7 @@ func (o Memory) Get(key string) ([]string, error) {
 
 	vals, ok := o.Data[key]
 	if !ok {
-		return nil, fmt.Errorf("key %q not found", key)
+		return nil, fmt.Errorf("%w: %q", ErrKeyNotFound, key)
 	}
 
 	return vals, nil

--- a/kvstore/memory_test.go
+++ b/kvstore/memory_test.go
@@ -178,7 +178,7 @@ func TestMemory_Del_ok(t *testing.T) {
 	err = s.Del(testKey)
 	assert.NoError(t, err)
 
-	expectedErr := fmt.Sprintf("key %q not found", testKey)
+	expectedErr := fmt.Sprintf("key not found: %q", testKey)
 
 	_, err = s.Get(testKey)
 	assert.EqualError(t, err, expectedErr)
@@ -191,9 +191,10 @@ func TestMemory_Get_no_such_key(t *testing.T) {
 	err := s.Init(cfg)
 	require.NoError(t, err)
 
-	expectedErr := fmt.Sprintf("key %q not found", testKey)
+	expectedErr := fmt.Sprintf("key not found: %q", testKey)
 
 	_, err = s.Get(testKey)
+	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.EqualError(t, err, expectedErr)
 }
 

--- a/kvstore/sql_test.go
+++ b/kvstore/sql_test.go
@@ -143,6 +143,27 @@ func TestSQL_Get_db_layer_failure(t *testing.T) {
 	}
 }
 
+func TestSQL_Get_key_not_found(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	s := SQL{TableName: "endorsement", DB: db}
+
+	e := mock.ExpectQuery(regexp.QuoteMeta("SELECT DISTINCT vals FROM endorsement WHERE key = ?"))
+	e.WithArgs("ninja")
+	e.WillReturnRows(sqlmock.NewRows([]string{"key", "vals"}))
+
+	expectedErr := "key not found: \"ninja\""
+
+	_, err = s.Get("ninja")
+	assert.EqualError(t, err, expectedErr)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %s", err)
+	}
+}
+
 func TestSQL_Get_broken_invariant_null_val_panic(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/vts/policymanager/Makefile
+++ b/vts/policymanager/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2022 Contributors to the Veraison project.
+# SPDX-License-Identifier: Apache-2.0
+
+.DEFAULT_GOAL := test
+
+INTERFACES := ../../policy/ibackend.go
+INTERFACES += ../../kvstore/ikvstore.go
+
+MOCKPKG := mocks
+
+lint-hook-pre: _mocks
+
+include ../../mk/common.mk
+include ../../mk/pkg.mk
+include ../../mk/lint.mk
+include ../../mk/test.mk

--- a/vts/policymanager/policymanager.go
+++ b/vts/policymanager/policymanager.go
@@ -67,6 +67,9 @@ func (o *PolicyManager) getPolicy(ev *proto.EvidenceContext) (*policy.Policy, er
 
 	vals, err := o.Store.Get(policyID)
 	if err != nil {
+		if errors.Is(err, kvstore.ErrKeyNotFound) {
+			return nil, fmt.Errorf("%w: %q", ErrNoPolicy, policyID)
+		}
 		return nil, err
 	}
 
@@ -74,7 +77,7 @@ func (o *PolicyManager) getPolicy(ev *proto.EvidenceContext) (*policy.Policy, er
 	// matching policy. Once we have a more sophisticated policy management
 	// framework worked out, we might allow multiple policies here.
 	if len(vals) == 0 {
-		return nil, ErrNoPolicy
+		return nil, fmt.Errorf("%w: %q", ErrNoPolicy, policyID)
 	} else if len(vals) > 1 {
 		return nil, fmt.Errorf("found %d policy entries for id %q; must be at most 1",
 			len(vals), policyID)

--- a/vts/policymanager/policymanager_test.go
+++ b/vts/policymanager/policymanager_test.go
@@ -1,0 +1,49 @@
+// Copyright 2022 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package policymanager
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/services/kvstore"
+	"github.com/veraison/services/policy"
+	"github.com/veraison/services/proto"
+	mock_deps "github.com/veraison/services/vts/policymanager/mocks"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func Test_getPolicy_not_found(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	store := mock_deps.NewMockIKVStore(ctrl)
+	store.EXPECT().
+		Get(gomock.Eq("opa://0/TPM_ENACTTRUST")).
+		Return(nil, kvstore.ErrKeyNotFound)
+
+	backend := mock_deps.NewMockIBackend(ctrl)
+	backend.EXPECT().
+		GetName().
+		Return("opa")
+
+	agent := policy.NewAgent(backend)
+
+	evStruct, err := structpb.NewStruct(nil)
+	require.NoError(t, err)
+
+	ec := &proto.EvidenceContext{
+		Format:        proto.AttestationFormat_TPM_ENACTTRUST,
+		TenantId:      "0",
+		TrustAnchorId: "TPM_ENACTTRUST://0/7df7714e-aa04-4638-bcbf-434b1dd720f1",
+		SoftwareId:    "TPM_ENACTTRUST://0/7df7714e-aa04-4638-bcbf-434b1dd720f1",
+		Evidence:      evStruct,
+	}
+
+	pm := &PolicyManager{Store: store, Agent: agent}
+
+	pol, err := pm.getPolicy(ec)
+	assert.Nil(t, pol)
+	assert.ErrorIs(t, err, ErrNoPolicy)
+}

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -228,7 +228,7 @@ func (o *GRPC) GetAttestation(ctx context.Context, token *proto.AttestationToken
 	}
 
 	endorsements, err := o.EnStore.Get(ec.SoftwareId)
-	if err != nil {
+	if err != nil && !errors.Is(err, kvstore.ErrKeyNotFound) {
 		return nil, err
 	}
 


### PR DESCRIPTION
- Handle key not being set inside a kvstore as a distinct case from other
  failure mode buy specifying a new error type.
- Fix the handling of policy not being found inside policymanager.
- Consider no endorsements being associated with a token to be a valid situation
  in the general case.

This addresses https://github.com/veraison/services/issues/25