### PR TITLE
vts: fix no policy case for policymanager

### DIFF
--- a/vts/policymanager/policymanager.go
+++ b/vts/policymanager/policymanager.go
@@ -40,7 +40,7 @@ func (o *PolicyManager) Evaluate(
 
 	policy, err := o.getPolicy(evidence)
 	if err != nil {
-		if err == ErrNoPolicy {
+		if errors.Is(err, ErrNoPolicy) {
 			return nil // No policy? No problem!
 		}
 


### PR DESCRIPTION
Use errors.Is to detect ErrNoPolicy that may be wrapped.

This (re-)addresses https://github.com/veraison/services/issues/25