### PR TITLE
policy: polcli version set from git

### DIFF
--- a/policy/cmd/polcli/commands/root.go
+++ b/policy/cmd/polcli/commands/root.go
@@ -4,6 +4,8 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/veraison/services/config"
 )
 
 var (
@@ -12,7 +14,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:     "polcli",
 		Short:   "policy management client",
-		Version: "0.0.1",
+		Version: config.Version,
 	}
 )
 


### PR DESCRIPTION
Specify config.Version (which gets populated at build time by git commit/tag) as the version for the executable.

Together with  https://github.com/veraison/services/pull/50, this implements https://github.com/veraison/services/issues/51