### PR TITLE
docker deployment + documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Copyright 2021 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
 
+export TOPDIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
 SUBDIR += config
 SUBDIR += kvstore
 SUBDIR += log

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,0 +1,151 @@
+# Args needs to be renewed for each build stage that uses these args
+ARG workDir=/app
+ARG workDirRepo=/app/services
+ARG GoVersion=1.18
+
+FROM golang:$GoVersion AS build-base
+
+# Renew Arg and set working directory to /app
+ARG workDir
+WORKDIR $workDir
+
+# Download go installation files
+RUN wget --progress=dot:giga https://raw.githubusercontent.com/veraison/services/main/go.mod &&\
+    wget --progress=dot:giga https://raw.githubusercontent.com/veraison/services/main/go.sum
+
+# Install build dependencies and tools
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+        --assume-yes \
+        --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        jq \
+        tree \
+        protobuf-compiler \
+        python3 \
+        python3-pip \
+        libprotobuf-dev \
+        libsqlite3-dev \
+        sqlite3 \
+        zlib1g-dev \
+    && apt-get clean \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
+
+# Install config templating dependencies
+RUN pip install --no-cache-dir Jinja2
+
+# Download Go modules
+RUN go mod download &&\
+    go install github.com/golang/mock/mockgen@v1.6.0 &&\
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26 &&\
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1 &&\
+    go install github.com/mitchellh/protoc-gen-go-json@v1.1.0 &&\
+    go install github.com/veraison/corim/cocli@demo-psa-1.0.0 &&\
+    go install github.com/veraison/evcli@demo-psa-1.0.0
+
+
+FROM build-base as common-build
+# Renew build arguments
+ARG workDirRepo
+ARG PROVISIONING_DEPLOY_PREFIX
+ARG VERIFICATION_DEPLOY_PREFIX
+ARG VTS_DEPLOY_PREFIX
+ARG VTS_PROVISIONING_LOCAL_IP_ADDRESS
+ARG VTS_VERIFICATION_LOCAL_IP_ADDRESS
+ARG VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT
+ARG VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT
+ARG BIN_DIR
+ARG LOG_DIR
+ARG PLUGIN_DIR
+ARG INPUT_FILE_DIR
+
+# Set envrionment variables for deploy directories and communication ip addresses
+ENV PROVISIONING_DEPLOY_PREFIX $workDirRepo$PROVISIONING_DEPLOY_PREFIX
+ENV VERIFICATION_DEPLOY_PREFIX $workDirRepo$VERIFICATION_DEPLOY_PREFIX
+ENV VTS_DEPLOY_PREFIX $workDirRepo$VTS_DEPLOY_PREFIX
+ENV VTS_PROVISIONING_LOCAL_IP_ADDRESS $VTS_PROVISIONING_LOCAL_IP_ADDRESS
+ENV VTS_VERIFICATION_LOCAL_IP_ADDRESS $VTS_VERIFICATION_LOCAL_IP_ADDRESS 
+ENV VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT $VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT
+ENV VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT $VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT
+
+# Set environment variables for binaries, logs, plugins and input directories
+ENV BIN_DIR $BIN_DIR
+ENV LOG_DIR $LOG_DIR
+ENV PLUGIN_DIR $PLUGIN_DIR
+ENV INPUT_FILE_DIR $INPUT_FILE_DIR
+
+# Clone deployment branch from remote (TODO: change this to clone from main once Docker change has been integrated)
+RUN git clone --branch deployment https://github.com/veraison/services.git
+
+# Set working directory to repo
+WORKDIR $workDirRepo
+
+# Generates a config for each service
+RUN cd $workDirRepo/deployments/docker &&\
+    python3 generate-config.py
+
+# Build and install binaries, logs, plugins and input directories
+RUN make && make install
+
+# Bundle the deploy directory into a tar file for each service
+RUN tar -cf provisioning.tar -C ${PROVISIONING_DEPLOY_PREFIX} . &&\
+    tar -cf verification.tar -C ${VERIFICATION_DEPLOY_PREFIX} . &&\
+    tar -cf vts.tar -C ${VTS_DEPLOY_PREFIX} .
+
+
+#### Provisioning service
+FROM build-base AS provisioning-run
+
+# Set environment variable for input directory for use inside the container
+ARG INPUT_FILE_DIR
+ENV INPUT_FILE_DIR $INPUT_FILE_DIR
+
+# Renew working directory arg
+ARG workDirRepo
+
+WORKDIR /
+
+# Copy over tar ball from build image
+COPY --from=common-build $workDirRepo/provisioning.tar /
+RUN tar -xf provisioning.tar
+EXPOSE 8888
+ENTRYPOINT [ "provisioning-service" ]
+CMD [ ]
+
+
+#### Verification service
+FROM build-base AS verification-run
+
+# Set environment variable for input directory for use inside the container
+ARG INPUT_FILE_DIR
+ENV INPUT_FILE_DIR $INPUT_FILE_DIR
+
+# Renew working directory arg
+ARG workDirRepo
+
+WORKDIR /
+
+# Copy over tar ball from build image
+COPY --from=common-build $workDirRepo/verification.tar /
+RUN tar -xf verification.tar && \
+    touch /etc/machine-id
+EXPOSE 8080
+ENTRYPOINT [ "verification-service" ]
+CMD [ ]
+
+
+#### VTS (Veraison Trusted Services)
+FROM build-base AS vts-run
+
+# Renew working directory arg
+ARG workDirRepo
+WORKDIR /
+
+# Copy over tar ball from build image
+COPY --from=common-build $workDirRepo/vts.tar /
+RUN tar -xf vts.tar
+RUN ["/bin/bash", "-c", "/init-kvstores.sh"]
+ENTRYPOINT [ "vts-service" ]
+CMD [ ]

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -1,0 +1,57 @@
+# Docker Deployment
+
+The structure of the docker deployment is as follows:
+- There are 3 containers; one for each service (provisioning, verification and vts)
+- There are two networks:
+    - `provisioning-network`: This network allows communication between VTS and the provisioning service
+    - `verification-network`: This network allows communication between VTS and the verification service
+
+## Dockerfile
+
+A [Dockerfile](./Dockerfile) is used to perform a multi-stage build that outputs the final image for each container:
+1. `build-base`: In this stage, the working directory is setup and project dependencies and libraries are installed
+2. `common-build`: 
+    - In this stage, build arguments that are passed in from the `docker-compose.yml` file, are used to establish the appropriate environment variables and the configs for each service are generated. 
+    - Files for each service are installed into the directory denoted by the environment variable `<service>_DEPLOY_PREFIX` using `make install` 
+    - Individual service directories are bundled into an individual tar file.
+3. `provisioning-run`: In this stage the `provisioning.tar` file is copied from the common-build image and extracted
+4. `verification-run`: In this stage the `verification.tar` file is copied from the common-build image and extracted
+5. `vts-run`: In this stage the `vts.tar` file is copied from the common-build image and extracted
+
+## Docker-compose
+
+The [docker-compose](./docker-compose.yml) functionality defines the configuration for each container and networks between each container.
+
+For dynamic configuration we pass in a `.env` file with the `docker compose up` command:
+
+
+-  Builds the images for the 3 containers
+```bash
+docker compose --env-file default.env build
+```
+
+-  Runs all 3 containers using the images built in the previous step
+```bash
+docker compose --env-file default.env up
+```
+
+- Tears down all 3 containers (this only removes the containers, not the images)
+```bash
+docker compose --env-file default.env down
+```
+NOTE: Ensure the above commands are run in the same directory as the `docker-compose.yml` and `Dockerfile`
+
+NOTE: The command in 3. is only needed if you need to rebuild the images (possibly because new input file, plugins, or code has been added)
+
+## Environment variables
+
+A `default.env` file which provides docker service configurations in the following way:
+- The `default.env` file is read into docker compose as the `--env-file` argument is specified in the 'build' and 'up' command
+- These environment variables are passed in as build arguments (variable substitution happens here) in the `docker-compose.yml` file
+- The `Dockerfile` takes the build arguments and initialises them as environment variables, ready for the build and installation process
+
+The `default.env` aims to provide a single source of configuration for individual services and docker configuration. The documentation on the current enviroment variables is provided in the [.env](default.env) file.
+
+## Configuration templating
+The [Jinja2](https://jinja.palletsprojects.com/en/3.1.x/templates/) templating engine is used to generate the configuration file for each individual service (provisioning, verification and vts). The templates are parsed and populated using the python script [generate-config.py](./generate-config.py). The templates take in environment variables to configure the service's settings. If the environment variable is unset or empty, the template is populated with its default value.
+ 

--- a/deployments/docker/config-templates/provisioning_tmpl.j2
+++ b/deployments/docker/config-templates/provisioning_tmpl.j2
@@ -1,0 +1,5 @@
+provisioning:
+  plugin-dir: {{ "../../plugins/bin/" | env_override('PLUGIN_DIR') }}
+  listen-addr: {{ "localhost:8888" }}
+vts:
+  server-addr: {{ "127.0.0.1" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS') }}:{{ "50051" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT') }}

--- a/deployments/docker/config-templates/verification_tmpl.j2
+++ b/deployments/docker/config-templates/verification_tmpl.j2
@@ -1,0 +1,4 @@
+verifier:
+
+vts:
+  server-addr: {{ "127.0.0.1" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS') }}:{{ "50051" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT') }}

--- a/deployments/docker/config-templates/vts_tmpl.j2
+++ b/deployments/docker/config-templates/vts_tmpl.j2
@@ -1,0 +1,17 @@
+plugin:
+  backend: {{ "go-plugin" }}
+  go-plugin:
+    folder: {{  "../../plugins/bin/" | env_override('PLUGIN_DIR') }}
+{% set stores = ['ta-store', 'en-store', 'po-store'] %}
+
+{% for store in stores %}
+{{ store }}: 
+  backend: {{ "sql" }}
+  sql:
+    driver: {{ "sqlite3" }}
+    datasource: {{ store ~ '.sql' }}
+{% endfor %}
+po-agent:
+  backend: {{ "opa" }}
+vts:
+  server-addr: {{ "127.0.0.1:50051" }}

--- a/deployments/docker/default.env
+++ b/deployments/docker/default.env
@@ -1,0 +1,24 @@
+# Deploy directory for each service
+PROVISIONING_DEPLOY_PREFIX=/deploy/provisioning
+VERIFICATION_DEPLOY_PREFIX=/deploy/verification
+VTS_DEPLOY_PREFIX=/deploy/vts
+
+# IP address and port number for communication between VTS and the provisioning service
+VTS_PROVISIONING_LOCAL_IP_ADDRESS=172.28.0.5
+VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT=50051
+
+# IP address and port number for communication between VTS and the verification service
+VTS_VERIFICATION_LOCAL_IP_ADDRESS=172.29.0.5
+VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT=50051
+
+# Install directory for project executables
+BIN_DIR=/usr/bin
+
+# Install directory for project logs
+LOG_DIR=/var/log/veraison-logs
+
+# Install directory for project plugins
+PLUGIN_DIR=/usr/share/veraison/plugins
+
+# Install directory for project input files
+INPUT_FILE_DIR=/usr/share/veraison/input

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -1,0 +1,93 @@
+version: '3.8'
+
+services:
+  provisioning:
+    build:
+      context: ../../
+      dockerfile: ./deployments/docker/Dockerfile
+      target: provisioning-run
+      args:
+        PROVISIONING_DEPLOY_PREFIX: ${PROVISIONING_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VERIFICATION_DEPLOY_PREFIX: ${VERIFICATION_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VTS_DEPLOY_PREFIX: ${VTS_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VTS_PROVISIONING_LOCAL_IP_ADDRESS: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+        VTS_VERIFICATION_LOCAL_IP_ADDRESS: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+        VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
+        VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
+        BIN_DIR: ${BIN_DIR:?Please define a value for the environment variable}
+        LOG_DIR: ${LOG_DIR:?Please define a value for the environment variable}
+        PLUGIN_DIR: ${PLUGIN_DIR:?Please define a value for the environment variable}
+        INPUT_FILE_DIR: ${INPUT_FILE_DIR:?Please define a value for the environment variable}
+    ports: 
+      - 8888:8888
+    depends_on:
+      - vts
+    networks:
+      - provisioning-network
+
+  verification:
+    build:
+      context: ../../
+      dockerfile: ./deployments/docker/Dockerfile
+      target: verification-run
+      args:
+        PROVISIONING_DEPLOY_PREFIX: ${PROVISIONING_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VERIFICATION_DEPLOY_PREFIX: ${VERIFICATION_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VTS_DEPLOY_PREFIX: ${VTS_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VTS_PROVISIONING_LOCAL_IP_ADDRESS: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+        VTS_VERIFICATION_LOCAL_IP_ADDRESS: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+        VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
+        VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
+        BIN_DIR: ${BIN_DIR:?Please define a value for the environment variable}
+        LOG_DIR: ${LOG_DIR:?Please define a value for the environment variable}
+        PLUGIN_DIR: ${PLUGIN_DIR:?Please define a value for the environment variable}
+        INPUT_FILE_DIR: ${INPUT_FILE_DIR:?Please define a value for the environment variable}
+    ports:
+      - 8080:8080
+    depends_on:
+      - vts
+    networks:
+      - verification-network
+
+
+  vts:
+    build:
+      context: ../../
+      dockerfile: ./deployments/docker/Dockerfile
+      target: vts-run
+      args:
+        PROVISIONING_DEPLOY_PREFIX: ${PROVISIONING_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VERIFICATION_DEPLOY_PREFIX: ${VERIFICATION_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VTS_DEPLOY_PREFIX: ${VTS_DEPLOY_PREFIX:?Please define a value for the environment variable}
+        VTS_PROVISIONING_LOCAL_IP_ADDRESS: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+        VTS_VERIFICATION_LOCAL_IP_ADDRESS: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+        VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
+        VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
+        BIN_DIR: ${BIN_DIR:?Please define a value for the environment variable}
+        LOG_DIR: ${LOG_DIR:?Please define a value for the environment variable}
+        PLUGIN_DIR: ${PLUGIN_DIR:?Please define a value for the environment variable}
+        INPUT_FILE_DIR: ${INPUT_FILE_DIR:?Please define a value for the environment variable}
+    networks:
+      provisioning-network:
+        ipv4_address: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+      verification-network:
+        ipv4_address: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+
+networks:
+  default:
+    external: true
+    name: none
+
+
+  provisioning-network:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16
+  
+  verification-network:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.29.0.0/16
+

--- a/deployments/docker/generate-config.py
+++ b/deployments/docker/generate-config.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import os
+from jinja2 import Environment, FileSystemLoader
+
+def env_override(default_value, key):
+    """ Gets value of the environment variable provided in the key """
+    return os.getenv(key, default_value)
+
+def generate_config(path_to_config_templates, path_to_new_config, curr_service):
+    # Load templates into Jinja environment
+    env = Environment(loader = FileSystemLoader(path_to_config_templates), trim_blocks=True, lstrip_blocks=True)
+    env.filters['env_override'] = env_override
+
+    # Renders config templates for each service into a config.yaml file
+    template = env.get_template(curr_service + '_tmpl.j2')
+    print(template.render())
+
+    file = open(path_to_new_config, 'w')
+    file.write(template.render())
+    file.close()
+
+# TODO Fix relative directory
+services = ["provisioning", "verification", "vts"]
+templates = "./config-templates"
+for service in services:
+    file = "../../" + service + "/cmd/" + service + "-service/config.yaml"
+    generate_config(templates, file, service)

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -9,3 +9,4 @@ export GO111MODULE := on
 # Used to set the ServerVersion reported by  services
 VERSION_FROM_GIT := $(shell git describe --tags --exact-match 2>/dev/null || echo -n "commit-$(shell git rev-parse --revs-only --short HEAD)")
 
+install:

--- a/provisioning/Makefile
+++ b/provisioning/Makefile
@@ -6,4 +6,15 @@ SUBDIR += api
 SUBDIR += plugins
 SUBDIR += cmd/provisioning-service
 
+# Create directories for packaging (TODO: May be a better way to do this)
+install:
+	mkdir -p $(PROVISIONING_DEPLOY_PREFIX)$(BIN_DIR)
+	mkdir -p $(PROVISIONING_DEPLOY_PREFIX)$(LOG_DIR)
+	mkdir -p $(PROVISIONING_DEPLOY_PREFIX)$(PLUGIN_DIR)
+	mkdir -p $(PROVISIONING_DEPLOY_PREFIX)$(INPUT_FILE_DIR)
+	install $(TOPDIR)/provisioning/cmd/provisioning-service/provisioning-service $(PROVISIONING_DEPLOY_PREFIX)$(BIN_DIR)/provisioning-service
+	install -D $(TOPDIR)/provisioning/plugins/bin/* $(PROVISIONING_DEPLOY_PREFIX)$(PLUGIN_DIR)
+	install $(TOPDIR)/provisioning/cmd/provisioning-service/config.yaml $(PROVISIONING_DEPLOY_PREFIX)/config.yaml
+	install $(TOPDIR)/end-to-end/input/corim-full.cbor $(PROVISIONING_DEPLOY_PREFIX)$(INPUT_FILE_DIR)
+
 include ../mk/subdir.mk

--- a/verification/Makefile
+++ b/verification/Makefile
@@ -6,4 +6,15 @@ SUBDIR += verifier
 SUBDIR += sessionmanager
 SUBDIR += cmd/verification-service
 
+# Create directories for packaging (TODO: May be a better way to do this)
+install:
+	mkdir -p $(VERIFICATION_DEPLOY_PREFIX)$(BIN_DIR)
+	mkdir -p $(VERIFICATION_DEPLOY_PREFIX)$(LOG_DIR)
+	mkdir -p $(VERIFICATION_DEPLOY_PREFIX)$(INPUT_FILE_DIR)
+	install $(TOPDIR)/verification/cmd/verification-service/verification-service $(VERIFICATION_DEPLOY_PREFIX)$(BIN_DIR)/verification-service
+	install $(TOPDIR)/verification/cmd/verification-service/config.yaml $(VERIFICATION_DEPLOY_PREFIX)/config.yaml
+	install $(TOPDIR)/end-to-end/input/psa-claims-profile-2-without-nonce.json $(VERIFICATION_DEPLOY_PREFIX)$(INPUT_FILE_DIR)
+	install $(TOPDIR)/end-to-end/input/psa-evidence.cbor $(VERIFICATION_DEPLOY_PREFIX)$(INPUT_FILE_DIR)
+	install $(TOPDIR)/end-to-end/input/ec-p256.jwk $(VERIFICATION_DEPLOY_PREFIX)$(INPUT_FILE_DIR)
+
 include ../mk/subdir.mk

--- a/vts/Makefile
+++ b/vts/Makefile
@@ -7,4 +7,15 @@ SUBDIR += pluginmanager
 SUBDIR += policymanager
 SUBDIR += cmd/vts-service
 
+# Create directories for packaging (TODO: May be a better way to do this)
+install:
+	mkdir -p $(VTS_DEPLOY_PREFIX)$(BIN_DIR)
+	mkdir -p $(VTS_DEPLOY_PREFIX)$(LOG_DIR)
+	mkdir -p $(VTS_DEPLOY_PREFIX)$(PLUGIN_DIR)
+	mkdir -p $(VTS_DEPLOY_PREFIX)/usr/share/veraison/stores
+	install $(TOPDIR)/vts/cmd/vts-service/vts-service $(VTS_DEPLOY_PREFIX)$(BIN_DIR)/vts-service
+	install -D $(TOPDIR)/vts/plugins/bin/* $(VTS_DEPLOY_PREFIX)$(PLUGIN_DIR)
+	install $(TOPDIR)/vts/cmd/vts-service/config.yaml $(VTS_DEPLOY_PREFIX)/config.yaml
+	install $(TOPDIR)/vts/test-harness/init-kvstores.sh $(VTS_DEPLOY_PREFIX)
+
 include ../mk/subdir.mk

--- a/vts/cmd/vts-service/config.yaml
+++ b/vts/cmd/vts-service/config.yaml
@@ -16,7 +16,7 @@ po-store:
   backend: sql
   sql:
     driver: sqlite3
-    datasource: en-store.sql
+    datasource: po-store.sql
 po-agent:
     backend: opa
 vts:

--- a/vts/test-harness/init-kvstores.sh
+++ b/vts/test-harness/init-kvstores.sh
@@ -6,7 +6,7 @@
 set -eux
 set -o pipefail
 
-for t in en ta
+for t in en ta po
 do
     echo "CREATE TABLE kvstore ( key text NOT NULL, vals text NOT NULL );" | \
         sqlite3 $t-store.sql


### PR DESCRIPTION
Previously, setting up the veraison services was complex as each service and their dependencies needed to be manually instantiated. This made the setting up demos time consuming. Now, veraison services can be built and deployed into containers using `docker compose`, allowing easy setup of demo environments. Configuration of the services within Docker have also been streamlined to obtain settings from a provided .env file.

This addresses #41 