### PR TITLE
Clarify CoRIM errors

### DIFF
--- a/provisioning/decoder/decoder_rpc.go
+++ b/provisioning/decoder/decoder_rpc.go
@@ -39,7 +39,7 @@ func (s *RPCServer) GetSupportedMediaTypes(args interface{}, resp *[]string) err
 func (s RPCServer) Decode(data []byte, resp *[]byte) error {
 	j, err := s.Impl.Decode(data)
 	if err != nil {
-		return fmt.Errorf("plugin returned error: %w", err)
+		return fmt.Errorf("plugin %q returned error: %w", s.Impl.GetName(), err)
 	}
 
 	*resp, err = protojson.Marshal(j)

--- a/provisioning/plugins/common/unsignedcorim_decoder.go
+++ b/provisioning/plugins/common/unsignedcorim_decoder.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/veraison/corim/comid"
 	"github.com/veraison/corim/corim"
@@ -46,7 +47,12 @@ func UnsignedCorimDecoder(data []byte, xtr IExtractor) (*decoder.EndorsementDeco
 	if uc.Profiles != nil {
 		// get the profile
 		if len(*uc.Profiles) > 1 {
-			return nil, fmt.Errorf("invalid multiple profiles: %x", len(*uc.Profiles))
+			var profiles []string
+			for _, p := range *uc.Profiles {
+				name, _ := p.Get()
+				profiles = append(profiles, name)
+			}
+			return nil, fmt.Errorf("found multiple profiles (expected exactly one): %s", strings.Join(profiles, ", "))
 		}
 		p := (*uc.Profiles)[0]
 		profile, err := p.Get()


### PR DESCRIPTION
A couple of small changes to make CoRIM decode errors clearer and more informative.