### PR TITLE
Add end to end integration test and make new integration test workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,34 @@
+# End to end integration tests - GitHub Actions
+name: integration tests
+on: [push, pull_request]
+jobs:
+  integration-tests-push:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Prepare environment variable
+      shell: bash
+      run: |
+        if [ "$GITHUB_EVENT_NAME" == "push" ]
+        then
+          echo $'\nGIT_CLONE_BRANCH=${GITHUB_REF_NAME}' >> ./deployments/docker/default.env
+        else
+          echo $'\nGIT_CLONE_BRANCH=${GITHUB_HEAD_REF}' >> ./deployments/docker/default.env
+        fi
+    - name: Setup services and integration tests containers
+      run: make -C integration-tests integration-tests-up
+    - name: Save test log and check for failures
+      run: |
+        docker logs -t -f tavern >> tavernTestLogs.log
+        grep 'FAILURES' tavernTestLogs.log | python3 scripts/integ-fail.py
+    - name: Save docker compose logs
+      run: docker-compose --env-file=deployments/docker/default.env --file=docker-compose-integration-tests.yml logs -f -t >> integration-tests.log &
+    - name: Archive container logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: container-logs
+        path: ./integration-tests.log
+    - name: Tear down services  
+      run: make -C integration-tests integration-tests-down

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -4,45 +4,9 @@ ARG workDirRepo=/app/services
 ARG GoVersion=1.18
 
 # Arguments for psa demo input directories
+# TODO create version associated with the tag by adding a release
 ARG COCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/corim@v0.0.0-20221125105155-c2835023f15e/cocli
 ARG EVCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/evcli@v0.0.0-20221212172836-49c7b2bdcf38/misc
-
-FROM golang:$GoVersion AS tavern-integration-tests
-ARG COCLI_TEMPLATES
-ARG EVCLI_TEMPLATES
-
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install \
-        --assume-yes \
-        --no-install-recommends \
-        apt-transport-https \
-        apt-utils \
-        python3-pip \
-    && apt-get clean \
-    && apt-get autoremove --assume-yes \
-    && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
-
-RUN go install github.com/veraison/corim/cocli@demo-psa-1.0.1 &&\
-    go install github.com/veraison/evcli@demo-psa-1.0.1 &&\
-    pip3 install tavern &&\
-    pip3 install cryptography
-
-COPY integration-tests/ /integration-tests/
-
-RUN cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-integ-iakpub.json &&\
-    cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-refval.json &&\ 
-    cocli corim create --template=$COCLI_TEMPLATES/data/templates/corim-full.json --comid=comid-psa-integ-iakpub.cbor --comid=comid-psa-refval.cbor &&\
-    mkdir /integration-tests/provisioning/ &&\
-    mv corim-full.cbor /integration-tests/provisioning/
-
-RUN evcli psa create -c $EVCLI_TEMPLATES/psa-claims-profile-2-integ.json -k $COCLI_TEMPLATES/data/keys/ec-p256.jwk --token=psa-evidence.cbor &&\
-    mkdir /integration-tests/verification/ &&\
-    mv psa-evidence.cbor /integration-tests/verification/ &&\
-    cp $COCLI_TEMPLATES/data/keys/ec-p256.jwk /integration-tests/verification/ &&\
-    cp $EVCLI_TEMPLATES/psa-claims-profile-2-integ.json /integration-tests/verification/ &&\
-    cp $EVCLI_TEMPLATES/psa-claims-profile-2-integ-without-nonce.json /integration-tests/verification/
-
-WORKDIR /
 
 FROM golang:$GoVersion AS build-base
 
@@ -107,6 +71,11 @@ ARG PROVISIONING_LISTENING_ADDRESS_AND_PORT
 ARG VERIFICATION_LISTENING_ADDRESS_AND_PORT
 ARG JWT_SIGNING_ALGORITHM
 ARG JWT_KEY_FILE_PATH
+ARG PROVISIONING_CONTAINER_NAME
+ARG VERIFICATION_CONTAINER_NAME
+ARG VTS_CONTAINER_NAME
+ARG VTS_PROVISIONING_NETWORK_ALIAS
+ARG VTS_VERIFICATION_NETWORK_ALIAS
 
 # Set envrionment variables for deploy directories and communication ports
 ENV PROVISIONING_DEPLOY_PREFIX $workDirRepo$PROVISIONING_DEPLOY_PREFIX
@@ -131,6 +100,13 @@ ENV VERIFICATION_LISTENING_ADDRESS_AND_PORT $VERIFICATION_LISTENING_ADDRESS_AND_
 # Set environment variable for JWT signing algorithm and key location
 ENV JWT_SIGNING_ALGORITHM $JWT_SIGNING_ALGORITHM
 ENV JWT_KEY_FILE_PATH $JWT_KEY_FILE_PATH
+
+# Set envrionment variables for host name and network aliases
+ENV PROVISIONING_CONTAINER_NAME $PROVISIONING_CONTAINER_NAME
+ENV VERIFICATION_CONTAINER_NAME $VERIFICATION_CONTAINER_NAME
+ENV VTS_CONTAINER_NAME $VTS_CONTAINER_NAME
+ENV VTS_PROVISIONING_NETWORK_ALIAS $VTS_PROVISIONING_NETWORK_ALIAS
+ENV VTS_VERIFICATION_NETWORK_ALIAS $VTS_VERIFICATION_NETWORK_ALIAS
 
 # Clone main branch from remote (at the demo tag)
 RUN git clone --depth 1 --branch ${GIT_CLONE_BRANCH} https://github.com/veraison/services.git

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -5,7 +5,44 @@ ARG GoVersion=1.18
 
 # Arguments for psa demo input directories
 ARG COCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/corim@v0.0.0-20221125105155-c2835023f15e/cocli
-ARG EVCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/evcli@v0.0.0-20221031171538-734499a0aa16/misc
+ARG EVCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/evcli@v0.0.0-20221212172836-49c7b2bdcf38/misc
+
+FROM golang:$GoVersion AS tavern-integration-tests
+ARG COCLI_TEMPLATES
+ARG EVCLI_TEMPLATES
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+        --assume-yes \
+        --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        python3-pip \
+    && apt-get clean \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
+
+RUN go install github.com/veraison/corim/cocli@demo-psa-1.0.1 &&\
+    go install github.com/veraison/evcli@demo-psa-1.0.1 &&\
+    pip3 install tavern &&\
+    pip3 install cryptography
+
+COPY integration-tests/ /integration-tests/
+
+RUN cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-integ-iakpub.json &&\
+    cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-refval.json &&\ 
+    cocli corim create --template=$COCLI_TEMPLATES/data/templates/corim-full.json --comid=comid-psa-integ-iakpub.cbor --comid=comid-psa-refval.cbor &&\
+    mkdir /integration-tests/provisioning/ &&\
+    mv corim-full.cbor /integration-tests/provisioning/
+
+RUN evcli psa create -c $EVCLI_TEMPLATES/psa-claims-profile-2-integ.json -k $COCLI_TEMPLATES/data/keys/ec-p256.jwk --token=psa-evidence.cbor &&\
+    mkdir /integration-tests/verification/ &&\
+    mv psa-evidence.cbor /integration-tests/verification/ &&\
+    cp $COCLI_TEMPLATES/data/keys/ec-p256.jwk /integration-tests/verification/ &&\
+    cp $EVCLI_TEMPLATES/psa-claims-profile-2-integ.json /integration-tests/verification/ &&\
+    cp $EVCLI_TEMPLATES/psa-claims-profile-2-integ-without-nonce.json /integration-tests/verification/
+
+WORKDIR /
 
 FROM golang:$GoVersion AS build-base
 
@@ -24,6 +61,7 @@ RUN apt-get update \
         --no-install-recommends \
         apt-transport-https \
         apt-utils \
+        iputils-ping \
         jq \
         tree \
         protobuf-compiler \
@@ -31,7 +69,9 @@ RUN apt-get update \
         python3-pip \
         libprotobuf-dev \
         libsqlite3-dev \
+        net-tools \
         sqlite3 \
+        vim \
         zlib1g-dev \
     && apt-get clean \
     && apt-get autoremove --assume-yes \
@@ -56,8 +96,6 @@ ARG workDirRepo
 ARG PROVISIONING_DEPLOY_PREFIX
 ARG VERIFICATION_DEPLOY_PREFIX
 ARG VTS_DEPLOY_PREFIX
-ARG VTS_PROVISIONING_LOCAL_IP_ADDRESS
-ARG VTS_VERIFICATION_LOCAL_IP_ADDRESS
 ARG VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT
 ARG VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT
 ARG BIN_DIR
@@ -65,13 +103,15 @@ ARG LOG_DIR
 ARG PLUGIN_DIR
 ARG INPUT_FILE_DIR
 ARG GIT_CLONE_BRANCH
+ARG PROVISIONING_LISTENING_ADDRESS_AND_PORT
+ARG VERIFICATION_LISTENING_ADDRESS_AND_PORT
+ARG JWT_SIGNING_ALGORITHM
+ARG JWT_KEY_FILE_PATH
 
-# Set envrionment variables for deploy directories and communication ip addresses
+# Set envrionment variables for deploy directories and communication ports
 ENV PROVISIONING_DEPLOY_PREFIX $workDirRepo$PROVISIONING_DEPLOY_PREFIX
 ENV VERIFICATION_DEPLOY_PREFIX $workDirRepo$VERIFICATION_DEPLOY_PREFIX
 ENV VTS_DEPLOY_PREFIX $workDirRepo$VTS_DEPLOY_PREFIX
-ENV VTS_PROVISIONING_LOCAL_IP_ADDRESS $VTS_PROVISIONING_LOCAL_IP_ADDRESS
-ENV VTS_VERIFICATION_LOCAL_IP_ADDRESS $VTS_VERIFICATION_LOCAL_IP_ADDRESS 
 ENV VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT $VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT
 ENV VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT $VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT
 
@@ -83,6 +123,14 @@ ENV INPUT_FILE_DIR $INPUT_FILE_DIR
 
 # Set environment variable for branch/tag to git clone from
 ENV GIT_CLONE_BRANCH $GIT_CLONE_BRANCH
+
+# Set environment variable for provisioning and verification listening address and port
+ENV PROVISIONING_LISTENING_ADDRESS_AND_PORT $PROVISIONING_LISTENING_ADDRESS_AND_PORT
+ENV VERIFICATION_LISTENING_ADDRESS_AND_PORT $VERIFICATION_LISTENING_ADDRESS_AND_PORT
+
+# Set environment variable for JWT signing algorithm and key location
+ENV JWT_SIGNING_ALGORITHM $JWT_SIGNING_ALGORITHM
+ENV JWT_KEY_FILE_PATH $JWT_KEY_FILE_PATH
 
 # Clone main branch from remote (at the demo tag)
 RUN git clone --depth 1 --branch ${GIT_CLONE_BRANCH} https://github.com/veraison/services.git

--- a/deployments/docker/config-templates/provisioning_tmpl.j2
+++ b/deployments/docker/config-templates/provisioning_tmpl.j2
@@ -2,4 +2,4 @@ provisioning:
   plugin-dir: {{ "../../plugins/bin/" | env_override('PLUGIN_DIR') }}
   listen-addr: {{ "localhost:8888" | env_override('PROVISIONING_LISTENING_ADDRESS_AND_PORT')}}
 vts:
-  server-addr: docker-vts-1.docker_provisioning-network:{{ "50051" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT') }}
+  server-addr: {{ "" | env_override('VTS_CONTAINER_NAME') }}.{{ "" | env_override('VTS_PROVISIONING_NETWORK_ALIAS') }}:{{ "50051" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT') }}

--- a/deployments/docker/config-templates/provisioning_tmpl.j2
+++ b/deployments/docker/config-templates/provisioning_tmpl.j2
@@ -1,5 +1,5 @@
 provisioning:
   plugin-dir: {{ "../../plugins/bin/" | env_override('PLUGIN_DIR') }}
-  listen-addr: {{ "localhost:8888" }}
+  listen-addr: {{ "localhost:8888" | env_override('PROVISIONING_LISTENING_ADDRESS_AND_PORT')}}
 vts:
-  server-addr: {{ "127.0.0.1" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS') }}:{{ "50051" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT') }}
+  server-addr: docker-vts-1.docker_provisioning-network:{{ "50051" | env_override('VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT') }}

--- a/deployments/docker/config-templates/verification_tmpl.j2
+++ b/deployments/docker/config-templates/verification_tmpl.j2
@@ -1,4 +1,5 @@
-verifier:
+verification:
+  listen-addr: {{ "localhost:8080" | env_override('VERIFICATION_LISTENING_ADDRESS_AND_PORT')}}
 
 vts:
-  server-addr: {{ "127.0.0.1" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS') }}:{{ "50051" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT') }}
+  server-addr: docker-vts-1.docker_verification-network:{{ "50051" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT') }}

--- a/deployments/docker/config-templates/verification_tmpl.j2
+++ b/deployments/docker/config-templates/verification_tmpl.j2
@@ -2,4 +2,4 @@ verification:
   listen-addr: {{ "localhost:8080" | env_override('VERIFICATION_LISTENING_ADDRESS_AND_PORT')}}
 
 vts:
-  server-addr: docker-vts-1.docker_verification-network:{{ "50051" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT') }}
+  server-addr: {{ "" | env_override('VTS_CONTAINER_NAME') }}.{{ "" | env_override('VTS_VERIFICATION_NETWORK_ALIAS') }}:{{ "50051" | env_override('VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT') }}

--- a/deployments/docker/config-templates/vts_tmpl.j2
+++ b/deployments/docker/config-templates/vts_tmpl.j2
@@ -15,3 +15,6 @@ po-agent:
   backend: {{ "opa" }}
 vts:
   server-addr: {{ "127.0.0.1:50051" }}
+ear-signer:
+  alg: {{  "ES256" | env_override('JWT_SIGNING_ALGORITHM') }}
+  key: {{  "./skey.jwk " | env_override('JWT_KEY_FILE_PATH') }}

--- a/deployments/docker/default.env
+++ b/deployments/docker/default.env
@@ -15,6 +15,15 @@ PROVISIONING_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8888
 # Verification listening address
 VERIFICATION_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8080
 
+# Host name for each service container
+PROVISIONING_CONTAINER_NAME=provisioning
+VERIFICATION_CONTAINER_NAME=verification
+VTS_CONTAINER_NAME=vts
+
+# Network name aliases for each network defined
+VTS_PROVISIONING_NETWORK_ALIAS=provisioning-network
+VTS_VERIFICATION_NETWORK_ALIAS=verification-network
+
 # Install directory for project executables
 BIN_DIR=/usr/bin
 

--- a/deployments/docker/default.env
+++ b/deployments/docker/default.env
@@ -3,13 +3,17 @@ PROVISIONING_DEPLOY_PREFIX=/deploy/provisioning
 VERIFICATION_DEPLOY_PREFIX=/deploy/verification
 VTS_DEPLOY_PREFIX=/deploy/vts
 
-# IP address and port number for communication between VTS and the provisioning service
-VTS_PROVISIONING_LOCAL_IP_ADDRESS=172.28.0.5
+# Port number for communication between VTS and the provisioning service
 VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT=50051
 
-# IP address and port number for communication between VTS and the verification service
-VTS_VERIFICATION_LOCAL_IP_ADDRESS=172.29.0.5
+# Port number for communication between VTS and the verification service
 VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT=50051
+
+# Provisioning listening address
+PROVISIONING_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8888
+
+# Verification listening address
+VERIFICATION_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8080
 
 # Install directory for project executables
 BIN_DIR=/usr/bin
@@ -25,3 +29,7 @@ INPUT_FILE_DIR=/usr/share/veraison/input
 
 # Branch/tag to clone the code from
 GIT_CLONE_BRANCH=main
+
+# JWT Signing algorithm and key location
+JWT_SIGNING_ALGORITHM=ES256
+JWT_KEY_FILE_PATH=./skey.jwk

--- a/deployments/docker/demo.env
+++ b/deployments/docker/demo.env
@@ -15,6 +15,15 @@ PROVISIONING_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8888
 # Verification listening address
 VERIFICATION_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8080
 
+# Host name for each service container
+PROVISIONING_CONTAINER_NAME=provisioning
+VERIFICATION_CONTAINER_NAME=verification
+VTS_CONTAINER_NAME=vts
+
+# Network name aliases for each network defined
+VTS_PROVISIONING_NETWORK_ALIAS=provisioning-network
+VTS_VERIFICATION_NETWORK_ALIAS=verification-network
+
 # Install directory for project executables
 BIN_DIR=/usr/bin
 

--- a/deployments/docker/demo.env
+++ b/deployments/docker/demo.env
@@ -3,13 +3,17 @@ PROVISIONING_DEPLOY_PREFIX=/deploy/provisioning
 VERIFICATION_DEPLOY_PREFIX=/deploy/verification
 VTS_DEPLOY_PREFIX=/deploy/vts
 
-# IP address and port number for communication between VTS and the provisioning service
-VTS_PROVISIONING_LOCAL_IP_ADDRESS=172.28.0.5
+# Port number for communication between VTS and the provisioning service
 VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT=50051
 
-# IP address and port number for communication between VTS and the verification service
-VTS_VERIFICATION_LOCAL_IP_ADDRESS=172.29.0.5
+# Port number for communication between VTS and the verification service
 VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT=50051
+
+# Provisioning listening address
+PROVISIONING_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8888
+
+# Verification listening address
+VERIFICATION_LISTENING_ADDRESS_AND_PORT=0.0.0.0:8080
 
 # Install directory for project executables
 BIN_DIR=/usr/bin
@@ -25,3 +29,7 @@ INPUT_FILE_DIR=/usr/share/veraison/input
 
 # Branch/tag to clone the code from
 GIT_CLONE_BRANCH=demo-psa-1.0.1
+
+# JWT Signing algorithm and key location
+JWT_SIGNING_ALGORITHM=ES256
+JWT_KEY_FILE_PATH=./skey.jwk

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -10,8 +10,6 @@ services:
         PROVISIONING_DEPLOY_PREFIX: ${PROVISIONING_DEPLOY_PREFIX:?Please define a value for the environment variable}
         VERIFICATION_DEPLOY_PREFIX: ${VERIFICATION_DEPLOY_PREFIX:?Please define a value for the environment variable}
         VTS_DEPLOY_PREFIX: ${VTS_DEPLOY_PREFIX:?Please define a value for the environment variable}
-        VTS_PROVISIONING_LOCAL_IP_ADDRESS: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
-        VTS_VERIFICATION_LOCAL_IP_ADDRESS: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
         VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
         VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
         BIN_DIR: ${BIN_DIR:?Please define a value for the environment variable}
@@ -19,6 +17,10 @@ services:
         PLUGIN_DIR: ${PLUGIN_DIR:?Please define a value for the environment variable}
         INPUT_FILE_DIR: ${INPUT_FILE_DIR:?Please define a value for the environment variable}
         GIT_CLONE_BRANCH: ${GIT_CLONE_BRANCH:?Please define a value for the environment variable}
+        PROVISIONING_LISTENING_ADDRESS_AND_PORT: ${PROVISIONING_LISTENING_ADDRESS_AND_PORT:?Please define a value for the environment variable}
+        VERIFICATION_LISTENING_ADDRESS_AND_PORT: ${VERIFICATION_LISTENING_ADDRESS_AND_PORT:?Please define a value for the environment variable}
+        JWT_SIGNING_ALGORITHM: ${JWT_SIGNING_ALGORITHM:?Please define a value for the environment variable}
+        JWT_KEY_FILE_PATH: ${JWT_KEY_FILE_PATH:?Please define a value for the environment variable}
     ports: 
       - 8888:8888
     depends_on:
@@ -35,8 +37,6 @@ services:
         PROVISIONING_DEPLOY_PREFIX: ${PROVISIONING_DEPLOY_PREFIX:?Please define a value for the environment variable}
         VERIFICATION_DEPLOY_PREFIX: ${VERIFICATION_DEPLOY_PREFIX:?Please define a value for the environment variable}
         VTS_DEPLOY_PREFIX: ${VTS_DEPLOY_PREFIX:?Please define a value for the environment variable}
-        VTS_PROVISIONING_LOCAL_IP_ADDRESS: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
-        VTS_VERIFICATION_LOCAL_IP_ADDRESS: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
         VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
         VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
         BIN_DIR: ${BIN_DIR:?Please define a value for the environment variable}
@@ -44,6 +44,10 @@ services:
         PLUGIN_DIR: ${PLUGIN_DIR:?Please define a value for the environment variable}
         INPUT_FILE_DIR: ${INPUT_FILE_DIR:?Please define a value for the environment variable}
         GIT_CLONE_BRANCH: ${GIT_CLONE_BRANCH:?Please define a value for the environment variable}
+        PROVISIONING_LISTENING_ADDRESS_AND_PORT: ${PROVISIONING_LISTENING_ADDRESS_AND_PORT:?Please define a value for the environment variable}
+        VERIFICATION_LISTENING_ADDRESS_AND_PORT: ${VERIFICATION_LISTENING_ADDRESS_AND_PORT:?Please define a value for the environment variable}
+        JWT_SIGNING_ALGORITHM: ${JWT_SIGNING_ALGORITHM:?Please define a value for the environment variable}
+        JWT_KEY_FILE_PATH: ${JWT_KEY_FILE_PATH:?Please define a value for the environment variable}
     ports:
       - 8080:8080
     depends_on:
@@ -61,8 +65,6 @@ services:
         PROVISIONING_DEPLOY_PREFIX: ${PROVISIONING_DEPLOY_PREFIX:?Please define a value for the environment variable}
         VERIFICATION_DEPLOY_PREFIX: ${VERIFICATION_DEPLOY_PREFIX:?Please define a value for the environment variable}
         VTS_DEPLOY_PREFIX: ${VTS_DEPLOY_PREFIX:?Please define a value for the environment variable}
-        VTS_PROVISIONING_LOCAL_IP_ADDRESS: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
-        VTS_VERIFICATION_LOCAL_IP_ADDRESS: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
         VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
         VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS_PORT:?Please define a value for the environment variable}
         BIN_DIR: ${BIN_DIR:?Please define a value for the environment variable}
@@ -70,11 +72,23 @@ services:
         PLUGIN_DIR: ${PLUGIN_DIR:?Please define a value for the environment variable}
         INPUT_FILE_DIR: ${INPUT_FILE_DIR:?Please define a value for the environment variable}
         GIT_CLONE_BRANCH: ${GIT_CLONE_BRANCH:?Please define a value for the environment variable}
+        PROVISIONING_LISTENING_ADDRESS_AND_PORT: ${PROVISIONING_LISTENING_ADDRESS_AND_PORT:?Please define a value for the environment variable}
+        VERIFICATION_LISTENING_ADDRESS_AND_PORT: ${VERIFICATION_LISTENING_ADDRESS_AND_PORT:?Please define a value for the environment variable}
+        JWT_SIGNING_ALGORITHM: ${JWT_SIGNING_ALGORITHM:?Please define a value for the environment variable}
+        JWT_KEY_FILE_PATH: ${JWT_KEY_FILE_PATH:?Please define a value for the environment variable}
     networks:
-      provisioning-network:
-        ipv4_address: ${VTS_PROVISIONING_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
-      verification-network:
-        ipv4_address: ${VTS_VERIFICATION_LOCAL_IP_ADDRESS:?Please define a value for the environment variable}
+      - provisioning-network
+      - verification-network
+  
+  tavern:
+    build:
+      context: ../../
+      dockerfile: ./deployments/docker/Dockerfile
+      target: tavern-integration-tests
+    command: sleep infinity
+    networks:
+      - provisioning-network
+      - verification-network
 
 networks:
   default:
@@ -85,12 +99,8 @@ networks:
   provisioning-network:
     ipam:
       driver: default
-      config:
-        - subnet: 172.28.0.0/16
   
   verification-network:
     ipam:
       driver: default
-      config:
-        - subnet: 172.29.0.0/16
 

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -1,0 +1,8 @@
+# Copyright 2022 Contributors to the Veraison project.
+# SPDX-License-Identifier: Apache-2.0
+
+integration-tests-up:
+	docker compose --env-file=../deployments/docker/default.env --file=docker-compose-integration-tests.yml up -d
+
+integration-tests-down:
+	docker compose --env-file=../deployments/docker/default.env --file=docker-compose-integration-tests.yml down

--- a/integration-tests/docker-compose-integration-tests.yml
+++ b/integration-tests/docker-compose-integration-tests.yml
@@ -4,7 +4,7 @@ services:
   provisioning:
     container_name: provisioning
     build:
-      context: ../../
+      context: ../
       dockerfile: ./deployments/docker/Dockerfile
       target: provisioning-run
       args:
@@ -37,7 +37,7 @@ services:
   verification:
     container_name: verification
     build:
-      context: ../../
+      context: ../
       dockerfile: ./deployments/docker/Dockerfile
       target: verification-run
       args:
@@ -71,7 +71,7 @@ services:
   vts:
     container_name: vts
     build:
-      context: ../../
+      context: ../
       dockerfile: ./deployments/docker/Dockerfile
       target: vts-run
       args:
@@ -94,6 +94,27 @@ services:
         VTS_CONTAINER_NAME: ${VTS_CONTAINER_NAME:?Please define a value for the environment variable}
         VTS_PROVISIONING_NETWORK_ALIAS: ${VTS_PROVISIONING_NETWORK_ALIAS:?Please define a value for the environment variable}
         VTS_VERIFICATION_NETWORK_ALIAS: ${VTS_VERIFICATION_NETWORK_ALIAS:?Please define a value for the environment variable}
+    networks:
+      - provisioning-network
+      - verification-network
+  
+  tavern:
+    container_name: tavern
+    build:
+      context: ../
+      dockerfile: ./integration-tests/tavern.Dockerfile
+      target: tavern-integration-tests
+      args:
+        PROVISIONING_CONTAINER_NAME: ${PROVISIONING_CONTAINER_NAME:?Please define a value for the environment variable}
+        VERIFICATION_CONTAINER_NAME: ${VERIFICATION_CONTAINER_NAME:?Please define a value for the environment variable}
+        VTS_CONTAINER_NAME: ${VTS_CONTAINER_NAME:?Please define a value for the environment variable}
+        VTS_PROVISIONING_NETWORK_ALIAS: ${VTS_PROVISIONING_NETWORK_ALIAS:?Please define a value for the environment variable}
+        VTS_VERIFICATION_NETWORK_ALIAS: ${VTS_VERIFICATION_NETWORK_ALIAS:?Please define a value for the environment variable}
+
+    depends_on:
+      - provisioning
+      - verification
+      - vts
     networks:
       - provisioning-network
       - verification-network

--- a/integration-tests/include.yaml
+++ b/integration-tests/include.yaml
@@ -1,0 +1,5 @@
+name: Common test information
+description: Response return information
+
+variables:
+  nonce: QUp8F0FBs9DpodKK8xUg8NQimf6sQAfe2J1ormzZLxk=

--- a/integration-tests/tavern.Dockerfile
+++ b/integration-tests/tavern.Dockerfile
@@ -1,0 +1,65 @@
+# go version for container image
+ARG GoVersion=1.18
+
+# Arguments for psa demo input directories
+# TODO create version associated with the tag by adding a release
+ARG COCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/corim@v0.0.0-20221125105155-c2835023f15e/cocli
+ARG EVCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/evcli@v0.0.0-20221212172836-49c7b2bdcf38/misc
+
+FROM golang:$GoVersion AS tavern-integration-tests
+WORKDIR /
+
+ARG COCLI_TEMPLATES
+ARG EVCLI_TEMPLATES
+
+ARG PROVISIONING_CONTAINER_NAME
+ARG VERIFICATION_CONTAINER_NAME
+ARG VTS_CONTAINER_NAME
+ARG VTS_PROVISIONING_NETWORK_ALIAS
+ARG VTS_VERIFICATION_NETWORK_ALIAS
+
+# Set envrionment variables for host name and netowrk aliases
+ENV PROVISIONING_CONTAINER_NAME $PROVISIONING_CONTAINER_NAME
+ENV VERIFICATION_CONTAINER_NAME $VERIFICATION_CONTAINER_NAME
+ENV VTS_CONTAINER_NAME $VTS_CONTAINER_NAME
+ENV VTS_PROVISIONING_NETWORK_ALIAS $VTS_PROVISIONING_NETWORK_ALIAS
+ENV VTS_VERIFICATION_NETWORK_ALIAS $VTS_VERIFICATION_NETWORK_ALIAS
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+        --assume-yes \
+        --no-install-recommends \
+        apt-transport-https \
+        apt-utils \
+        python3-pip \
+    && apt-get clean \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
+
+RUN go install github.com/veraison/corim/cocli@demo-psa-1.0.1 &&\
+    go install github.com/veraison/evcli@demo-psa-1.0.1 &&\
+    pip3 install tavern &&\
+    pip3 install python-jose
+
+
+COPY integration-tests/ /integration-tests/
+
+WORKDIR /integration-tests/extra
+RUN cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-integ-iakpub.json &&\
+    cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-refval.json &&\ 
+    cocli corim create --template=$COCLI_TEMPLATES/data/templates/corim-full.json --comid=comid-psa-integ-iakpub.cbor --comid=comid-psa-refval.cbor &&\
+    mkdir /integration-tests/provisioning/ &&\
+    mv corim-full.cbor /integration-tests/provisioning/
+
+RUN evcli psa create -c $EVCLI_TEMPLATES/psa-claims-profile-2-integ.json -k $COCLI_TEMPLATES/data/keys/ec-p256.jwk --token=psa-evidence.cbor &&\
+    mkdir /integration-tests/verification/ &&\
+    mv psa-evidence.cbor /integration-tests/verification/ &&\
+    cp $COCLI_TEMPLATES/data/keys/ec-p256.jwk /integration-tests/verification/ &&\
+    cp $EVCLI_TEMPLATES/psa-claims-profile-2-integ.json /integration-tests/verification/ &&\
+    cp $EVCLI_TEMPLATES/psa-claims-profile-2-integ-without-nonce.json /integration-tests/verification/
+
+WORKDIR /integration-tests/verification
+RUN wget --progress=dot:giga https://raw.githubusercontent.com/veraison/services/main/vts/cmd/vts-service/skey.jwk 
+
+WORKDIR /
+CMD PYTHONPATH=$PYTHONPATH:integration-tests py.test integration-tests/ -vv

--- a/integration-tests/test_end_to_end_success.tavern.yaml
+++ b/integration-tests/test_end_to_end_success.tavern.yaml
@@ -7,35 +7,33 @@ strict:
   - json:off
 
 stages:
-  - name: submit post request to the provisioning service sucessfully 
+  - name: submit post request to the provisioning service successfully 
     request:
       method: POST
-      url: http://docker-provisioning-1.docker_provisioning-network:8888/endorsement-provisioning/v1/submit
+      url: http://{tavern.env_vars.PROVISIONING_CONTAINER_NAME}.{tavern.env_vars.VTS_PROVISIONING_NETWORK_ALIAS}:8888/endorsement-provisioning/v1/submit
       headers:
-        Content-type: "application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
+        content-type: "application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
       file_body: ./integration-tests/provisioning/corim-full.cbor
     response:
       status_code: 200
     
-  
-
   - name: verify as relying party - creation of resource
     request:
       method: POST
-      url: "http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/newSession?nonce={nonce:s}"
+      url: "http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/newSession?nonce={nonce:s}"
     response:
       status_code: 201 
       save:
         headers:
-          location-relyp: Location
+          relying-party-session: Location
 
   - name: verify as relying party - submitting the evidence
     request:
       method: POST
-      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-relyp}'
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{relying-party-session}'
       file_body: ./integration-tests/verification/psa-evidence.cbor
       headers:
-        Content-type: application/psa-attestation-token
+        content-type: application/psa-attestation-token
     response:
       status_code: 200
       json:
@@ -44,37 +42,38 @@ stages:
         - function: test_utils:verify_attestation_results
           extra_args:
           - ./integration-tests/verification/psa-claims-profile-2-integ.json
+          - ./integration-tests/verification/skey.jwk
       
       
-  - name: verify as relying party - deleting the evidence
+  - name: verify as relying party - deleting the session object
     request:
       method: DELETE
-      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-relyp}'
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{relying-party-session}'
       headers:
-        Content-type: application/psa-attestation-token
+        content-type: application/psa-attestation-token
     response:
       status_code: 204
 
 
-  - name: verify as attester - creation of resource
+  - name: verify as attester - creation of session resource
     request:
       method: POST
-      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/newSession?nonceSize=32'
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/newSession?nonceSize=32'
     response:
       status_code: 201
       verify_response_with:
         function: test_utils:generate_token
       save:
         headers:
-          location-attester: Location
+          attester-session: Location
 
 
   - name: verify as attester - submitting the evidence
     request:
       method: POST
-      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-attester}'
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{attester-session}'
       headers:
-        Content-type: application/psa-attestation-token
+        content-type: application/psa-attestation-token
       file_body: ./integration-tests/verification/my.cbor
     response:
       status_code: 200
@@ -82,13 +81,14 @@ stages:
         - function: test_utils:verify_attestation_results
           extra_args:
           - ./integration-tests/verification/psa-claims-profile-2-integ-without-nonce.json
+          - ./integration-tests/verification/skey.jwk
 
-  - name: verify as attester - deleting the evidence
+  - name: verify as attester - deleting the session object
     request:
       method: DELETE
-      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-attester}'
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{attester-session}'
       headers:
-        Content-type: application/psa-attestation-token
+        content-type: application/psa-attestation-token
     response:
       status_code: 204
 

--- a/integration-tests/test_end_to_end_success.tavern.yaml
+++ b/integration-tests/test_end_to_end_success.tavern.yaml
@@ -1,0 +1,99 @@
+test_name: Test veraison end to end success
+
+includes:
+  - !include include.yaml
+
+strict:
+  - json:off
+
+stages:
+  - name: submit post request to the provisioning service sucessfully 
+    request:
+      method: POST
+      url: http://docker-provisioning-1.docker_provisioning-network:8888/endorsement-provisioning/v1/submit
+      headers:
+        Content-type: "application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
+      file_body: ./integration-tests/provisioning/corim-full.cbor
+    response:
+      status_code: 200
+    
+  
+
+  - name: verify as relying party - creation of resource
+    request:
+      method: POST
+      url: "http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/newSession?nonce={nonce:s}"
+    response:
+      status_code: 201 
+      save:
+        headers:
+          location-relyp: Location
+
+  - name: verify as relying party - submitting the evidence
+    request:
+      method: POST
+      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-relyp}'
+      file_body: ./integration-tests/verification/psa-evidence.cbor
+      headers:
+        Content-type: application/psa-attestation-token
+    response:
+      status_code: 200
+      json:
+        nonce: "{nonce:s}"
+      verify_response_with:
+        - function: test_utils:verify_attestation_results
+          extra_args:
+          - ./integration-tests/verification/psa-claims-profile-2-integ.json
+      
+      
+  - name: verify as relying party - deleting the evidence
+    request:
+      method: DELETE
+      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-relyp}'
+      headers:
+        Content-type: application/psa-attestation-token
+    response:
+      status_code: 204
+
+
+  - name: verify as attester - creation of resource
+    request:
+      method: POST
+      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/newSession?nonceSize=32'
+    response:
+      status_code: 201
+      verify_response_with:
+        function: test_utils:generate_token
+      save:
+        headers:
+          location-attester: Location
+
+
+  - name: verify as attester - submitting the evidence
+    request:
+      method: POST
+      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-attester}'
+      headers:
+        Content-type: application/psa-attestation-token
+      file_body: ./integration-tests/verification/my.cbor
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: test_utils:verify_attestation_results
+          extra_args:
+          - ./integration-tests/verification/psa-claims-profile-2-integ-without-nonce.json
+
+  - name: verify as attester - deleting the evidence
+    request:
+      method: DELETE
+      url: 'http://docker-verification-1.docker_verification-network:8080/challenge-response/v1/{location-attester}'
+      headers:
+        Content-type: application/psa-attestation-token
+    response:
+      status_code: 204
+
+ 
+
+  
+
+  

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import jwt
+
+def write_json(new_data, filename):
+    with open(filename,'r+') as file:
+        # Load existing data into a dict
+        file_data = json.load(file)
+        
+        if file_data == None:
+            return 1
+
+        # Join new_data with file_data
+        file_data.update(new_data)
+        # Set file's current position at offset.
+        file.seek(0)
+        # Convert back to json
+        json.dump(file_data, file, indent = 4) 
+
+        return 0
+
+
+def generate_token(response):
+    # Obtain nonce value from resource creation response 
+    nonce_val = {"psa-nonce": response.json()["nonce"]}
+    
+    # Add nonce to json template
+    success_nonce = write_json(nonce_val, './integration-tests/verification/psa-claims-profile-2-integ-without-nonce.json')
+
+    # Generate token with evcli using template with nonce and key
+    evcli_create = subprocess.run(['evcli psa create --claims=./integration-tests/verification/psa-claims-profile-2-integ-without-nonce.json --key=./integration-tests/verification/ec-p256.jwk --token=./integration-tests/verification/my.cbor'], shell=True)
+
+    assert success_nonce == 0 and evcli_create.returncode == 0
+
+def verify_attestation_results(response, template):
+    currJWT = response.json()["result"]
+    decoded = jwt.decode(currJWT, options={"verify_signature": False})
+
+    # template = './integration-tests/verification/psa-claims-profile-2-integ.json'
+    with open(template,'r+') as file:
+        # Load existing data into a dict
+        file_data = json.load(file)
+        
+        if file_data == None:
+            return 1
+
+    assert decoded["ear.status"] == "affirming"
+
+    for key in decoded["ear.veraison.processed-evidence"]:
+        assert decoded["ear.veraison.processed-evidence"][key] == file_data[key]
+
+    

--- a/scripts/integ-fail.py
+++ b/scripts/integ-fail.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 Contributors to the Veraison project.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import re
+import sys
+
+# read output of docker container running integration tests 
+failure_lines = sys.stdin.read()
+
+if len(failure_lines) == 0:
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/vts/Makefile
+++ b/vts/Makefile
@@ -16,6 +16,7 @@ install:
 	install $(TOPDIR)/vts/cmd/vts-service/vts-service $(VTS_DEPLOY_PREFIX)$(BIN_DIR)/vts-service
 	install -D $(TOPDIR)/vts/plugins/bin/* $(VTS_DEPLOY_PREFIX)$(PLUGIN_DIR)
 	install $(TOPDIR)/vts/cmd/vts-service/config.yaml $(VTS_DEPLOY_PREFIX)/config.yaml
-	install $(TOPDIR)/vts/test-harness/init-kvstores.sh $(VTS_DEPLOY_PREFIX)
+	install $(TOPDIR)/vts/test-harness/init-kvstores.sh $(VTS_DEPLOY_PREFIX)/init-kvstores.sh
+	install $(TOPDIR)/vts/cmd/vts-service/skey.jwk $(VTS_DEPLOY_PREFIX)/skey.jwk
 
 include ../mk/subdir.mk


### PR DESCRIPTION
This change implements:
- An end to end integration test using Tavern (a pytest based API testing framework)
- A new Github action workflow to integrate the integration tests into the CI pipeline

This addresses #84 
