### PR TITLE
Add integration test documentation and negative testing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@
 name: integration tests
 on: [push, pull_request]
 jobs:
-  integration-tests-push:
+  integration-tests:
     name: Run integration tests
     runs-on: ubuntu-latest
     steps:
@@ -19,16 +19,24 @@ jobs:
         fi
     - name: Setup services and integration tests containers
       run: make -C integration-tests integration-tests-up
-    - name: Save test log and check for failures
-      run: |
-        docker logs -t -f tavern >> tavernTestLogs.log
-        grep 'FAILURES' tavernTestLogs.log | python3 scripts/integ-fail.py
+    - name: Save test log
+      run: docker logs -t -f tavern | tee tavern-tests.log &
+    - name: Archive tavern container log
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: tavern-logs
+        path: ./tavern-tests.log
+    - name: Check for failures
+      run: grep 'FAILURES' tavern-tests.log | python3 scripts/integ-fail.py
     - name: Save docker compose logs
-      run: docker-compose --env-file=deployments/docker/default.env --file=docker-compose-integration-tests.yml logs -f -t >> integration-tests.log &
+      if: always()
+      run: docker-compose --env-file=deployments/docker/default.env --file=integration-tests/docker-compose-integration-tests.yml logs -f -t --no-color | tee container.log &
     - name: Archive container logs
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: container-logs
-        path: ./integration-tests.log
+        path: ./container.log
     - name: Tear down services  
       run: make -C integration-tests integration-tests-down

--- a/deployments/docker/default.env
+++ b/deployments/docker/default.env
@@ -42,3 +42,9 @@ GIT_CLONE_BRANCH=main
 # JWT Signing algorithm and key location
 JWT_SIGNING_ALGORITHM=ES256
 JWT_KEY_FILE_PATH=./skey.jwk
+
+# Test vector file locations
+# TODO create version associated with the tag by adding a release
+COCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/corim@v0.0.0-20221125105155-c2835023f15e/cocli
+EVCLI_TEMPLATES=/go/pkg/mod/github.com/veraison/evcli@v0.0.0-20221212172836-49c7b2bdcf38/misc
+DIAG_FILES=/go/pkg/mod/github.com/veraison/psatoken@v1.0.0-rc2/testvectors/cbor

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,82 @@
+# Integration tests with Tavern
+
+Useful aspects to note before getting started:
+- Tests are defined in YAML files, and each new test must have a file name with the following format: `test_<test_name>.tavern.yaml`
+- Tavern tests are run in a separate container (called `tavern`)
+- Tests will only run sucessfully once the full docker environment of all services and test containers are setup 
+
+## Structure of Tavern test cases
+- Each Tavern test has a test name and can consist of several stages
+- Each stage has request information such as a HTTP method, url, headers etc, that you submit a request with
+- Each stage has a response field that is populated with the response you expect for that specific request
+    - For example to validate that the key-value pair `val: none` is present in the response the `json` field needs to be checked:
+    ```yaml
+    response:
+        status_code: 200
+        json:
+            nonce: "{nonce:s}"
+    ```
+- Values from a response can be saved for use in subsequent stages. For example the below saves the Location field in the `header`, into the variable `my-var` which can be used in subsequent stages within the same test:
+    ```yaml
+    response:
+        ....
+        save:
+            headers:
+                my-var: Location
+    ```
+- External functions can be written and used to customise validation: 
+    ```yaml
+    response:
+        ....
+        verify_response_with:
+            - function: <file_name_with_function>:<func_name>
+    ```
+
+## Setup integration test environment to run tests locally
+Below are the steps to setup the environment and run the integration tests:
+
+1. Open `integration-tests/docker-compose-integration-tests.yml` file and paste the `command` entry into the tavern service configuration, inline with build and volume configurations:
+
+```yaml
+build:
+    ....
+volumes:
+    ....
+command: sleep infinity
+```
+Explaination of volumes: this configuration mounts your local `integration-tests` directory into the container at the location `/integration-tests` in the container. Each time you edit a test file locally, the changes will update in the container. This means you wont have to rebuild the docker containers each time you want edit your test. 
+
+Explaination of command: The purpose of the command `sleep infinity` is to allow the container to stay alive so you can shell into the container and run the tests manually.
+
+WARNING: Remember to remove the `command: sleep infinity` line before commiting your changes!
+
+2. Change to the integration-tests directory locally and setup the docker containers by running the below make command.
+
+```bash
+cd services/integration-tests
+make integration-tests-up
+```
+
+3. Use the following command to attach to the logs of the running services to see the live logs.
+
+```
+docker compose \
+    --env-file=../deployments/docker/default.env \
+    --file=docker-compose-integration-tests.yml \
+    logs -f -t
+```
+
+4. In another terminal, use this command to shell into the tavern test container (this will give you access to an interactive bash shell inside the tavern docker container).
+
+```bash
+docker exec -it tavern bash
+```
+
+5. Run the tests using the following command in the shell of the container. Make sure you are in the root directory of the container when running the command.
+
+```bash
+PYTHONPATH=$PYTHONPATH:integration-tests \
+    py.test integration-tests/ -vv
+```
+
+

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import os.path
+import pytest
+
+
+@pytest.fixture(name='remove_cbor')
+def psa_clean_up_cbor_generated_token():
+    # Check if my.cbor exists and delete it
+    my_cbor = "/test-vectors/provisioning/cbor/psa-good-evidence.cbor"
+    exists = os.path.isfile(my_cbor)
+    if exists:
+        del_success = subprocess.run(["rm /test-vectors/provisioning/cbor/psa-good-evidence.cbor"], shell=True)
+        assert del_success.returncode == 0
+
+
+@pytest.fixture
+def psa_generate_good_provisioning_cbor():
+    cocli_cmd = """
+                cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-integ-iakpub.json &&
+                cocli comid create --template=$COCLI_TEMPLATES/data/templates/comid-psa-refval.json && 
+                cocli corim create --template=$COCLI_TEMPLATES/data/templates/corim-full.json --comid=comid-psa-integ-iakpub.cbor --comid=comid-psa-refval.cbor &&
+                mv corim-full.cbor /test-vectors/provisioning/cbor &&
+                mv comid-psa-integ-iakpub.cbor /test-vectors/provisioning/cbor &&
+                mv comid-psa-refval.cbor /test-vectors/provisioning/cbor
+    """
+    success = subprocess.run(cocli_cmd, shell=True)
+    assert success.returncode == 0
+
+@pytest.fixture
+def psa_generate_good_evidence():
+    evcli_cmd = """
+                evcli psa create -c /test-vectors/verification/json/psa-claims-profile-2-integ.json -k /test-vectors/verification/keys/ec-p256.jwk --token=psa-good-evidence.cbor &&
+                mv psa-good-evidence.cbor /test-vectors/verification/cbor
+    """
+    success = subprocess.run(evcli_cmd, shell=True)
+    assert success.returncode == 0
+
+
+@pytest.fixture
+def psa_generate_bad_swcomp_evidence():
+    template = "/test-vectors/verification/json/psa-claims-profile-2-integ.json"
+    bad_swcomp_template = "/test-vectors/verification/json/psa-claims-profile-2-integ-bad-swcomp.json"
+    create_new_file = subprocess.run(["cp " + template + " " + bad_swcomp_template], shell=True)
+    assert create_new_file.returncode == 0
+
+    with open(bad_swcomp_template,'r+') as file:
+        # Load existing data into a dict
+        file_data = json.load(file)
+        
+        if file_data == None:
+            return 1
+
+        # Extract and distort BL software component measurement
+        BL_measurement = list(file_data["psa-software-components"][0]["measurement-value"])
+        BL_measurement[0] = "H"
+        final_BL = "".join(BL_measurement)
+        file_data["psa-software-components"][0]["measurement-value"] = final_BL
+
+        # Set file's current position at offset.
+        file.seek(0)
+        # Convert back to json
+        json.dump(file_data, file, indent = 4) 
+
+    evcli_cmd = """
+                evcli psa create -c /test-vectors/verification/json/psa-claims-profile-2-integ-bad-swcomp.json -k /test-vectors/verification/keys/ec-p256.jwk --token=psa-bad-swcomp-evidence.cbor &&
+                mv psa-bad-swcomp-evidence.cbor /test-vectors/verification/cbor
+    """
+
+    success = subprocess.run(evcli_cmd, shell=True)
+    assert success.returncode == 0

--- a/integration-tests/docker-compose-integration-tests.yml
+++ b/integration-tests/docker-compose-integration-tests.yml
@@ -110,6 +110,15 @@ services:
         VTS_CONTAINER_NAME: ${VTS_CONTAINER_NAME:?Please define a value for the environment variable}
         VTS_PROVISIONING_NETWORK_ALIAS: ${VTS_PROVISIONING_NETWORK_ALIAS:?Please define a value for the environment variable}
         VTS_VERIFICATION_NETWORK_ALIAS: ${VTS_VERIFICATION_NETWORK_ALIAS:?Please define a value for the environment variable}
+        COCLI_TEMPLATES: ${COCLI_TEMPLATES:?Please define a value for the environment variable}
+        EVCLI_TEMPLATES: ${EVCLI_TEMPLATES:?Please define a value for the environment variable}
+        DIAG_FILES: ${DIAG_FILES:?Please define a value for the environment variable}
+    volumes:
+      # Volume to mount local integration test files into container
+      - type: bind
+        source: ../integration-tests/
+        target: /integration-tests
+
 
     depends_on:
       - provisioning

--- a/integration-tests/include.yaml
+++ b/integration-tests/include.yaml
@@ -2,4 +2,5 @@ name: Common test information
 description: Response return information
 
 variables:
-  nonce: QUp8F0FBs9DpodKK8xUg8NQimf6sQAfe2J1ormzZLxk=
+  good-nonce: QUp8F0FBs9DpodKK8xUg8NQimf6sQAfe2J1ormzZLxk=
+  bad-nonce: Ppfdfe2JzZLOk=

--- a/integration-tests/test_bad_swcomp_claim.tavern.yaml
+++ b/integration-tests/test_bad_swcomp_claim.tavern.yaml
@@ -1,10 +1,10 @@
-test_name: Test veraison end to end success
+test_name: Test use of bad BL software component measurement value in evidence
 
 marks:
   - usefixtures:
       - remove_cbor
       - psa_generate_good_provisioning_cbor
-      - psa_generate_good_evidence
+      - psa_generate_bad_swcomp_evidence
 
 includes:
   - !include include.yaml
@@ -37,65 +37,26 @@ stages:
     request:
       method: POST
       url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{relying-party-session}'
-      file_body: /test-vectors/verification/cbor/psa-good-evidence.cbor
+      file_body: /test-vectors/verification/cbor/psa-bad-swcomp-evidence.cbor
       headers:
         content-type: application/psa-attestation-token
     response:
       status_code: 200
       json:
         nonce: "{good-nonce:s}"
+        status: complete
       verify_response_with:
-        - function: test_utils:verify_good_attestation_results
+        - function: test_utils:verify_bad_swcomp_attestation_results
           extra_args:
-          - /test-vectors/verification/json/psa-claims-profile-2-integ.json
+          - /test-vectors/verification/json/psa-claims-profile-2-integ-bad-swcomp.json
           - /test-vectors/verification/keys/skey.jwk
-      
+     
       
   - name: verify as relying party - deleting the session object
     request:
       method: DELETE
       url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{relying-party-session}'
-    response:
-      status_code: 204
-
-
-  - name: verify as attester - creation of session resource
-    request:
-      method: POST
-      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/newSession?nonceSize=32'
-    response:
-      status_code: 201
-      verify_response_with:
-        function: test_utils:generate_token
-      save:
-        headers:
-          attester-session: Location
-
-
-  - name: verify as attester - submitting the evidence
-    request:
-      method: POST
-      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{attester-session}'
       headers:
         content-type: application/psa-attestation-token
-      file_body: /test-vectors/verification/cbor/attester.cbor
-    response:
-      status_code: 200
-      verify_response_with:
-        - function: test_utils:verify_good_attestation_results
-          extra_args:
-          - /test-vectors/verification/json/psa-claims-profile-2-integ-with-nonce.json
-          - /test-vectors/verification/keys/skey.jwk
-
-  - name: verify as attester - deleting the session object
-    request:
-      method: DELETE
-      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/{attester-session}'
     response:
       status_code: 204
-
- 
-
-  
-
-  

--- a/integration-tests/test_provisioning_unsuccessful.tavern.yaml
+++ b/integration-tests/test_provisioning_unsuccessful.tavern.yaml
@@ -1,0 +1,21 @@
+test_name: Test unsuccessful provisioning (no cbor file provided)
+
+
+includes:
+  - !include include.yaml
+
+strict:
+  - json:off
+
+stages:
+  - name: submit post request to the provisioning service successfully 
+    request:
+      method: POST
+      url: http://{tavern.env_vars.PROVISIONING_CONTAINER_NAME}.{tavern.env_vars.VTS_PROVISIONING_NETWORK_ALIAS}:8888/endorsement-provisioning/v1/submit
+      headers:
+        content-type: "application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
+    response:
+      status_code: 400
+      json:
+        title: Bad Request
+        detail: empty body

--- a/integration-tests/test_verification_bad_nonce_relying_party.tavern.yaml
+++ b/integration-tests/test_verification_bad_nonce_relying_party.tavern.yaml
@@ -1,0 +1,28 @@
+test_name: Test with bad nonce value in replying party session
+
+includes:
+  - !include include.yaml
+
+strict:
+  - json:off
+
+stages:
+  - name: submit post request to the provisioning service successfully 
+    request:
+      method: POST
+      url: http://{tavern.env_vars.PROVISIONING_CONTAINER_NAME}.{tavern.env_vars.VTS_PROVISIONING_NETWORK_ALIAS}:8888/endorsement-provisioning/v1/submit
+      headers:
+        content-type: "application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
+      file_body: /test-vectors/provisioning/cbor/corim-full.cbor
+    response:
+      status_code: 200
+
+  - name: verify as relying party - creation of resource with bad nonce
+    request:
+      method: POST
+      url: "http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/newSession?nonce={bad-nonce:s}"
+    response:
+      status_code: 400
+      json:
+        title: Bad Request
+        detail: 'failed handling nonce request: nonce must be valid base64'

--- a/integration-tests/test_verification_bad_session_attester.tavern.yaml
+++ b/integration-tests/test_verification_bad_session_attester.tavern.yaml
@@ -1,0 +1,40 @@
+test_name: Test without creation of nonce for attester session
+
+marks:
+  - usefixtures:
+      - remove_cbor
+      - psa_generate_good_evidence
+
+strict:
+  - json:off
+
+stages:
+  - name: submit post request to the provisioning service successfully 
+    request:
+      method: POST
+      url: http://{tavern.env_vars.PROVISIONING_CONTAINER_NAME}.{tavern.env_vars.VTS_PROVISIONING_NETWORK_ALIAS}:8888/endorsement-provisioning/v1/submit
+      headers:
+        content-type: "application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
+      file_body: /test-vectors/provisioning/cbor/corim-full.cbor
+    response:
+      status_code: 200
+
+  - name: verify as attester - creation of session resource
+    request:
+      method: POST
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/newSession?nonceSize=32'
+    response:
+      status_code: 201
+      verify_response_with:
+        function: test_utils:generate_token
+
+  - name: verify as attester - submitting the evidence
+    request:
+      method: POST
+      url: 'http://{tavern.env_vars.VERIFICATION_CONTAINER_NAME}.{tavern.env_vars.VTS_VERIFICATION_NETWORK_ALIAS}:8080/challenge-response/v1/1111-2222-3333'
+      headers:
+        content-type: application/psa-attestation-token
+      file_body: /test-vectors/verification/cbor/psa-good-evidence.cbor
+    response:
+      # Outputs a "Could not find request resource" error
+      status_code: 404


### PR DESCRIPTION
This change adds documentation describing how to write end to end integration tests using the python Tavern testing framework. This change also adds some negative end to end tests that test the HTTP responses when given incorrect stimuli.

This work contributes to #84 