### PR TITLE
Add discovery API unit tests

### DIFF
--- a/capability/well-known.go
+++ b/capability/well-known.go
@@ -4,20 +4,24 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
+const (
+	WellKnownMediaType = "application/vnd.veraison.discovery+json"
+)
+
 type WellKnownInfo struct {
 	PublicKey    jwk.Key           `json:"ear-verification-key,omitempty"`
 	MediaTypes   []string          `json:"media-types"`
 	Version      string            `json:"version"`
-	State        string            `json:"state"`
+	ServiceState string            `json:"service-state"`
 	ApiEndpoints map[string]string `json:"api-endpoints"`
 }
 
-func NewWellKnownInfoObj(key jwk.Key, mediaTypes []string, version string, state string, endpoints map[string]string) (*WellKnownInfo, error) {
+func NewWellKnownInfoObj(key jwk.Key, mediaTypes []string, version string, serviceState string, endpoints map[string]string) (*WellKnownInfo, error) {
 	obj := &WellKnownInfo{
 		PublicKey:    key,
 		MediaTypes:   mediaTypes,
 		Version:      version,
-		State:        state,
+		ServiceState: serviceState,
 		ApiEndpoints: endpoints,
 	}
 

--- a/provisioning/api/handler.go
+++ b/provisioning/api/handler.go
@@ -288,6 +288,15 @@ func getProvisioningEndpoints() map[string]string {
 }
 
 func (o *Handler) GetWellKnownProvisioningInfo(c *gin.Context) {
+	offered := c.NegotiateFormat(capability.WellKnownMediaType)
+	if offered != capability.WellKnownMediaType && offered != gin.MIMEJSON {
+		ReportProblem(c,
+			http.StatusNotAcceptable,
+			fmt.Sprintf("the only supported output format is %s", capability.WellKnownMediaType),
+		)
+		return
+	}
+
 	// Get provisioning media types
 	mediaTypes, err := o.getProvisioningMediaTypes()
 	if err != nil {
@@ -321,5 +330,6 @@ func (o *Handler) GetWellKnownProvisioningInfo(c *gin.Context) {
 		return
 	}
 
+	c.Header("Content-Type", capability.WellKnownMediaType)
 	c.JSON(http.StatusOK, obj)
 }

--- a/provisioning/api/handler_test.go
+++ b/provisioning/api/handler_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/moogar0880/problems"
 	"github.com/stretchr/testify/assert"
+	"github.com/veraison/services/capability"
 	"github.com/veraison/services/handler"
 	"github.com/veraison/services/log"
 	"github.com/veraison/services/proto"
 	mock_deps "github.com/veraison/services/provisioning/api/mocks"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var (
@@ -43,6 +45,10 @@ var (
 	}
 	testGoodRefValRes = proto.AddRefValuesResponse{
 		Status: &proto.Status{Result: true},
+	}
+	testGoodServiceState = proto.ServiceState{
+		Status:        2,
+		ServerVersion: "3.2",
 	}
 )
 
@@ -565,4 +571,162 @@ func TestHandler_Submit_ok(t *testing.T) {
 	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
 	assert.Nil(t, body.FailureReason)
 	assert.Equal(t, expectedStatus, body.Status)
+}
+
+func TestHandler_GetWellKnownProvisioningInfo_ok(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	supportedMediaTypes := []string{"application/type-1", "application/type-2"}
+
+	dm := mock_deps.NewMockIManager[handler.IEndorsementHandler](ctrl)
+	dm.EXPECT().
+		GetRegisteredMediaTypes().
+		Return(supportedMediaTypes)
+
+	sc := mock_deps.NewMockIVTSClient(ctrl)
+	sc.EXPECT().
+		GetServiceState(
+			gomock.Eq(context.TODO()),
+			gomock.Eq(&emptypb.Empty{}),
+		).
+		Return(&testGoodServiceState, nil)
+
+	h := NewHandler(dm, sc, log.Named("test"))
+
+	expectedCode := http.StatusOK
+	expectedType := capability.WellKnownMediaType
+	expectedBody := capability.WellKnownInfo{
+		MediaTypes:   supportedMediaTypes,
+		Version:      testGoodServiceState.ServerVersion,
+		ServiceState: testGoodServiceState.Status.String(),
+		ApiEndpoints: publicApiMap,
+	}
+
+	w := httptest.NewRecorder()
+	g, _ := gin.CreateTestContext(w)
+
+	g.Request, _ = http.NewRequest(http.MethodGet, "/.well-known/veraison/provisioning", http.NoBody)
+	g.Request.Header.Add("Accept", expectedType)
+
+	NewRouter(h).ServeHTTP(w, g.Request)
+
+	var body capability.WellKnownInfo
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, body)
+}
+
+func TestHandler_GetWellKnownProvisioningInfo_GetRegisteredMediaTypes_empty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dm := mock_deps.NewMockIManager[handler.IEndorsementHandler](ctrl)
+	dm.EXPECT().
+		GetRegisteredMediaTypes().
+		Return([]string{})
+
+	sc := mock_deps.NewMockIVTSClient(ctrl)
+	sc.EXPECT().
+		GetServiceState(
+			gomock.Eq(context.TODO()),
+			gomock.Eq(&emptypb.Empty{}),
+		).
+		Return(&testGoodServiceState, nil)
+
+	h := NewHandler(dm, sc, log.Named("test"))
+
+	expectedCode := http.StatusOK
+	expectedType := capability.WellKnownMediaType
+	expectedBody := capability.WellKnownInfo{
+		MediaTypes:   []string{},
+		Version:      testGoodServiceState.ServerVersion,
+		ServiceState: testGoodServiceState.Status.String(),
+		ApiEndpoints: publicApiMap,
+	}
+
+	w := httptest.NewRecorder()
+	g, _ := gin.CreateTestContext(w)
+
+	g.Request, _ = http.NewRequest(http.MethodGet, "/.well-known/veraison/provisioning", http.NoBody)
+	g.Request.Header.Add("Accept", expectedType)
+
+	NewRouter(h).ServeHTTP(w, g.Request)
+
+	var body capability.WellKnownInfo
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, body)
+}
+
+func TestHandler_GetWellKnownProvisioningInfo_GetServiceState_fail(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	supportedMediaTypes := []string{"application/type-1", "application/type-2"}
+
+	dm := mock_deps.NewMockIManager[handler.IEndorsementHandler](ctrl)
+	dm.EXPECT().
+		GetRegisteredMediaTypes().
+		Return(supportedMediaTypes)
+
+	sc := mock_deps.NewMockIVTSClient(ctrl)
+	sc.EXPECT().
+		GetServiceState(
+			gomock.Eq(context.TODO()),
+			gomock.Eq(&emptypb.Empty{}),
+		).
+		Return(nil, errors.New("blah"))
+
+	h := NewHandler(dm, sc, log.Named("test"))
+
+	expectedCode := http.StatusInternalServerError
+	expectedType := "application/problem+json"
+	expectedErrorTitle := "Internal Server Error"
+
+	w := httptest.NewRecorder()
+	g, _ := gin.CreateTestContext(w)
+
+	g.Request, _ = http.NewRequest(http.MethodGet, "/.well-known/veraison/provisioning", http.NoBody)
+
+	NewRouter(h).ServeHTTP(w, g.Request)
+
+	var body problems.DefaultProblem
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedErrorTitle, body.Title)
+}
+
+func TestHandler_GetWellKnownProvisioningInfo_UnsupportedAccept(t *testing.T) {
+	h := &Handler{}
+
+	expectedCode := http.StatusNotAcceptable
+	expectedType := "application/problem+json"
+	expectedBody := problems.DefaultProblem{
+		Type:   "about:blank",
+		Title:  "Not Acceptable",
+		Status: http.StatusNotAcceptable,
+		Detail: fmt.Sprintf("the only supported output format is %s", capability.WellKnownMediaType),
+	}
+
+	w := httptest.NewRecorder()
+	g, _ := gin.CreateTestContext(w)
+
+	g.Request, _ = http.NewRequest(http.MethodGet, "/.well-known/veraison/provisioning", http.NoBody)
+	g.Request.Header.Add("Accept", "application/unsupported+ber")
+
+	NewRouter(h).ServeHTTP(w, g.Request)
+
+	var body problems.DefaultProblem
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, body)
 }

--- a/provisioning/api/router.go
+++ b/provisioning/api/router.go
@@ -10,7 +10,6 @@ var publicApiMap = make(map[string]string)
 
 const (
 	provisioningSubmitUrl           = "/endorsement-provisioning/v1/submit"
-	getServiceStateUrl              = "/status"
 	getWellKnownProvisioningInfoUrl = "/.well-known/veraison/provisioning"
 )
 
@@ -22,8 +21,6 @@ func NewRouter(handler IHandler) *gin.Engine {
 
 	router.POST(provisioningSubmitUrl, handler.Submit)
 	publicApiMap["provisioningSubmit"] = provisioningSubmitUrl
-
-	router.GET(getServiceStateUrl, handler.GetServiceState)
 
 	router.GET(getWellKnownProvisioningInfoUrl, handler.GetWellKnownProvisioningInfo)
 

--- a/verification/api/handler.go
+++ b/verification/api/handler.go
@@ -513,6 +513,15 @@ func getVerificationEndpoints() map[string]string {
 }
 
 func (o *Handler) GetWellKnownVerificationInfo(c *gin.Context) {
+	offered := c.NegotiateFormat(capability.WellKnownMediaType)
+	if offered != capability.WellKnownMediaType && offered != gin.MIMEJSON {
+		ReportProblem(c,
+			http.StatusNotAcceptable,
+			fmt.Sprintf("the only supported output format is %s", capability.WellKnownMediaType),
+		)
+		return
+	}
+
 	// Get public key
 	key, err := o.getKey()
 	if err != nil {
@@ -556,5 +565,6 @@ func (o *Handler) GetWellKnownVerificationInfo(c *gin.Context) {
 		return
 	}
 
+	c.Header("Content-Type", capability.WellKnownMediaType)
 	c.JSON(http.StatusOK, obj)
 }

--- a/verification/api/router.go
+++ b/verification/api/router.go
@@ -13,7 +13,6 @@ const (
 	submitEvidenceUrl               = "/challenge-response/v1/session/:id"
 	getSessionUrl                   = "/challenge-response/v1/session/:id"
 	delSessionUrl                   = "/challenge-response/v1/session/:id"
-	getServiceStateUrl              = "/status"
 	getWellKnownVerificationInfoUrl = "/.well-known/veraison/verification"
 )
 
@@ -31,8 +30,6 @@ func NewRouter(handler IHandler) *gin.Engine {
 	router.GET(getSessionUrl, handler.GetSession)
 
 	router.DELETE(delSessionUrl, handler.DelSession)
-
-	router.GET(getServiceStateUrl, handler.GetServiceState)
 
 	router.GET(getWellKnownVerificationInfoUrl, handler.GetWellKnownVerificationInfo)
 


### PR DESCRIPTION
This change adds unit tests to test the implemented discovery APIs

This addresses #80 