### PR TITLE
Faulty evidence error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ deployments/docker/.bin
 integration-tests/.built
 __generated__
 __pycache__
+__debug_bin
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ COVERAGE_THRESHOLD := 60.0
 # tested. plugin/test coverage is low because it's purely test code).
 IGNORE_COVERAGE += github.com/veraison/services/plugin
 IGNORE_COVERAGE += github.com/veraison/services/plugin/test
+# There is protobuf-generated stuff here, which skews coverage.
+IGNORE_COVERAGE += github.com/veraison/services/handler
 
 include mk/cover.mk
 

--- a/deployments/docker/Makefile
+++ b/deployments/docker/Makefile
@@ -165,7 +165,8 @@ docker-clean:
 	docker volume rm -f veraison-logs veraison-stores
 	@# ubuntu uses an older version of docker without -f option for network; hence the || : cludge
 	docker network rm $(VERAISON_NETWORK) || :
-	docker image rm -f veraison/builder veraison/vts veraison/provisioning veraison/verification
+	docker image rm -f veraison/builder veraison/vts veraison/provisioning \
+		veraison/verification veraison/manager
 	rm -rf  .built
 
 .PHONY: host-clean

--- a/deployments/docker/src/builder-dispatcher
+++ b/deployments/docker/src/builder-dispatcher
@@ -34,6 +34,7 @@ function deploy() {
     cp $BUILD_DIR/vts/cmd/vts-service/vts-service $DEPLOY_DIR/
     cp $BUILD_DIR/scheme/bin/* $DEPLOY_DIR/plugins/
     cp $BUILD_DIR/deployments/docker/src/skey.jwk $DEPLOY_DIR/
+    cp $BUILD_DIR/deployments/docker/src/service-entrypoint $DEPLOY_DIR/
     cp $BUILD_DIR/policy/cmd/polcli/polcli $DEPLOY_DIR/utils/
     cp $gobin/evcli $DEPLOY_DIR/utils/
     cp $gobin/cocli $DEPLOY_DIR/utils/

--- a/deployments/docker/src/manager-dispatcher
+++ b/deployments/docker/src/manager-dispatcher
@@ -41,6 +41,12 @@ function logs() {
     cp $_logs_dir/* $dest/
 }
 
+function clear_logs() {
+    for f in $(ls $_logs_dir); do
+        echo "" > $_logs_dir/$f
+    done
+}
+
 function cocli() {
     local cmd="$_utils_dir/cocli $@"
     /bin/bash -c "$cmd"
@@ -71,6 +77,7 @@ case $command in
     stores | check-stores) stores "$@";;
     clear-stores) clear_stores "$@";;
     logs | get-logs) logs "$@";;
+    clear-logs) clear_logs "$@";;
     cocli)  cocli "$@";;
     evcli)  evcli "$@";;
     polcli)  polcli "$@";;

--- a/deployments/docker/src/provisioning.docker
+++ b/deployments/docker/src/provisioning.docker
@@ -23,7 +23,8 @@ WORKDIR /opt/veraison
 RUN mkdir logs
 
 ADD --chown=veraison:nogroup plugins plugins
-ADD --chown=veraison:nogroup config.yaml provisioning-service ./
+ADD --chown=veraison:nogroup config.yaml provisioning-service service-entrypoint ./
 
-ENTRYPOINT ["/opt/veraison/provisioning-service"]
+ENTRYPOINT ["/opt/veraison/service-entrypoint"]
+CMD ["/opt/veraison/provisioning-service"]
 

--- a/deployments/docker/src/service-entrypoint
+++ b/deployments/docker/src/service-entrypoint
@@ -1,0 +1,4 @@
+#!/bin/bash
+umask 0002
+exec "$@"
+

--- a/deployments/docker/src/verification.docker
+++ b/deployments/docker/src/verification.docker
@@ -22,7 +22,8 @@ WORKDIR /opt/veraison
 
 RUN mkdir logs
 
-ADD --chown=veraison:nogroup config.yaml verification-service ./
+ADD --chown=veraison:nogroup config.yaml verification-service service-entrypoint ./
 
-ENTRYPOINT ["/opt/veraison/verification-service"]
+ENTRYPOINT ["/opt/veraison/service-entrypoint"]
+CMD ["/opt/veraison/verification-service"]
 

--- a/deployments/docker/src/vts.docker
+++ b/deployments/docker/src/vts.docker
@@ -35,8 +35,9 @@ RUN mkdir -p --mode=0775 stores/vts
 
 ADD --chown=veraison:nogroup plugins plugins
 ADD --chown=veraison:veraison --chmod=0660 stores/* stores/vts
-ADD --chown=veraison:nogroup config.yaml skey.jwk vts-service ./
+ADD --chown=veraison:nogroup config.yaml skey.jwk vts-service service-entrypoint ./
 
 
-ENTRYPOINT ["/opt/veraison/vts-service"]
+ENTRYPOINT ["/opt/veraison/service-entrypoint"]
+CMD ["/opt/veraison/vts-service"]
 

--- a/deployments/docker/veraison
+++ b/deployments/docker/veraison
@@ -165,6 +165,10 @@ function logs() {
     rmdir __veraison_logs
 }
 
+function clear_logs() {
+    manager clear-logs $@
+}
+
 function create_tmux_session() {
     _check_installed tmux
 
@@ -427,6 +431,7 @@ case $command in
     stores | check-stores) stores $2;;
     clear-stores) clear_stores $2;;
     logs | get-logs) logs $2;;
+    clear-logs) clear_logs $2;;
     start-tmux) create_tmux_session $2;;
     tmux | attach-tmux) attach_tmux_session $2;;
     stop-tmux | kill-tmux) kill_tmux_session $2;;

--- a/handler/error.go
+++ b/handler/error.go
@@ -1,0 +1,227 @@
+// Copyright 2023 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// BadEvidenceError represents an error due a problem with the received evidence.
+// IEvidenceHandler implementations should return an instance of this
+// (constructed using BadEvidence() below) if they could not process the
+// provided evidence token.
+type BadEvidenceError struct {
+	Detail interface{}
+}
+
+// The goal of MarshalJSON and UnmarshalJSON below is to make
+// serialization/deserialization as transparrent as possible. This means
+// accurately preserving Detail's structure.
+
+func (o BadEvidenceError) MarshalJSON() ([]byte, error) {
+	m := map[string]interface{}{
+		"error": "bad evidence",
+	}
+
+	switch t := o.Detail.(type) {
+	case string:
+		m["detail-type"] = "string"
+		m["detail"] = t
+	case error:
+		err := t
+		var msgs []string
+		for {
+			msgs = append(msgs, err.Error())
+			if uerr, ok := err.(interface{ Unwrap() error }); ok {
+				err = uerr.Unwrap()
+			} else {
+				break
+			}
+		}
+
+		m["detail-type"] = "error"
+		m["detail"] = msgs
+	default:
+		m["detail-type"] = "other"
+		m["detail"] = o.Detail
+	}
+
+	return json.Marshal(m)
+}
+
+func (o *BadEvidenceError) UnmarshalJSON(data []byte) error {
+	var m map[string]interface{}
+
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+
+	errType, ok := m["error"]
+	if !ok || errType != "bad evidence" {
+		return errors.New("not a BadEvidenceError")
+	}
+
+	detailType, ok := m["detail-type"]
+	if !ok {
+		return errors.New("missing detail-type")
+	}
+	switch detailType {
+	case "string":
+		switch t := m["detail"].(type) {
+		case string:
+			o.Detail = t
+		case []byte:
+			o.Detail = string(t)
+		default:
+			return fmt.Errorf("unexpected value for string detail: %v (%T)", t, t)
+		}
+	case "error":
+		switch t := m["detail"].(type) {
+		case []interface{}:
+			if len(t) < 1 { // nolint:gocritic
+				return errors.New("empty messages for error detail")
+			} else if len(t) == 1 {
+				o.Detail = errors.New(fmt.Sprint(t[0]))
+			} else {
+				err := errors.New(fmt.Sprint(t[len(t)-1]))
+				for i := len(t) - 2; i >= 0; i-- {
+					err = wraptError{
+						msg: fmt.Sprint(t[i]),
+						err: err,
+					}
+				}
+				o.Detail = err
+			}
+		default:
+			return fmt.Errorf("unexpected value for string detail: %v (%T)", t, t)
+		}
+	case "other":
+		o.Detail = m["detail"]
+	default:
+		return fmt.Errorf("unexpected detail type: %s", detailType)
+	}
+
+	return nil
+}
+
+func (o BadEvidenceError) Error() string {
+	data, err := o.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	return string(data)
+}
+
+func (o BadEvidenceError) ToString() string {
+	switch t := o.Detail.(type) {
+	case string:
+		return fmt.Sprintf("bad evidence: %s", t)
+	case error:
+		return fmt.Sprintf("bad evidence: %s", t.Error())
+	default:
+		return fmt.Sprintf("bad evidence: %v", t)
+	}
+}
+
+func (o BadEvidenceError) Unwrap() error {
+	switch t := o.Detail.(type) {
+	case error:
+		return t
+	default:
+		return nil
+	}
+}
+
+func (o BadEvidenceError) Is(other error) bool {
+	if _, ok := other.(BadEvidenceError); ok {
+		return true
+	}
+
+	if wrapt, ok := other.(interface{ Unwrap() error }); ok {
+		return o.Is(wrapt.Unwrap())
+	}
+
+	return false
+}
+
+// BadEvidence creates a new BadEvidenceError instance using the provided args
+// to construct the detail. If no args are specified, the generic detail of
+// "invalid"  is used. If exactly one argument is specified, it is used as the
+// detial. If more than one ergument is specified, the behavior depends on the
+// type of the first argument.
+// When args[0] is a string a new error is created using fmt.Errorf, using
+// args[0] as the format, and that error is used as the detail.
+// Otherwise, the entire args slice is used as the detail.
+func BadEvidence(args ...interface{}) error {
+	var detail interface{}
+
+	switch len(args) {
+	case 0:
+		detail = "invalid"
+	case 1:
+		detail = args[0]
+	default: // args longer than 1
+		switch t := args[0].(type) {
+		case string:
+			detail = fmt.Errorf(t, args[1:]...)
+		default:
+			detail = args[0]
+		}
+	}
+
+	return BadEvidenceError{detail}
+}
+
+func ParseError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+
+	if strings.HasPrefix(msg, "bad evidence: ") {
+		return BadEvidenceError{msg[14:]}
+	}
+
+	var bee BadEvidenceError
+	var decErr error
+	if decErr = json.Unmarshal([]byte(msg), &bee); decErr == nil {
+		return bee
+	}
+
+	return err
+}
+
+type wraptError struct {
+	msg string
+	err error
+}
+
+func (o wraptError) Error() string {
+	return o.msg
+}
+
+func (o wraptError) Unwrap() error {
+	return o.err
+}
+
+func (o wraptError) Is(other error) bool {
+	if o.Error() == other.Error() {
+		return true
+	}
+
+	if _, ok := o.err.(wraptError); !ok {
+		// We've  at the the final wrapping layer. errors.Is uses == to
+		// establish error (i.e. interface{}) equality, since that
+		// amounts to comparing pointers, equality won't be preserved
+		// across serialization/desrialization. Therefore, we need to
+		// do string comparison rather than rely on errors.Is.
+		return o.err.Error() == other.Error()
+	}
+
+	return errors.Is(o.err, other)
+}

--- a/handler/error_test.go
+++ b/handler/error_test.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_BadEvidenceError_marshalling_roundtrip(t *testing.T) {
+	type TestVector struct {
+		Title string
+		Bee   BadEvidenceError
+	}
+	tvs := []TestVector{
+		{"string-unexpected", BadEvidenceError{"error"}},
+		{"error-unexpected", BadEvidenceError{errors.New("error")}},
+		{"wrapped-unexpected", BadEvidenceError{
+			fmt.Errorf("wrapped: %w", errors.New("error")),
+		}},
+		{"int-unexpected", BadEvidenceError{42}},
+		{"string-crypto", BadEvidenceError{"wrong key"}},
+	}
+
+	for _, tv := range tvs {
+		fmt.Println(tv.Title)
+
+		data, err := json.Marshal(tv.Bee)
+		require.NoError(t, err)
+
+		var decoded BadEvidenceError
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, decoded.Error(), tv.Bee.Error())
+	}
+}
+
+func Test_BadEvidenceError_parse(t *testing.T) {
+	expected := BadEvidenceError{"something went wrong"}
+
+	input := errors.New("bad evidence: something went wrong")
+
+	err := ParseError(input)
+
+	assert.True(t, errors.Is(err, expected))
+	assert.Equal(t, expected.Error(), err.Error())
+
+	input2 := errors.New(expected.Error())
+
+	err = ParseError(input2)
+
+	assert.True(t, errors.Is(err, expected))
+	assert.Equal(t, expected.Error(), err.Error())
+}
+
+func Test_BadEvidenceError_is(t *testing.T) {
+	bee := BadEvidence("error")
+
+	assert.True(t, errors.Is(bee, BadEvidenceError{}))
+	assert.True(t, errors.Is(BadEvidenceError{}, bee))
+
+	err := fmt.Errorf("caught: %w", bee)
+	assert.True(t, errors.Is(err, BadEvidenceError{}))
+	assert.True(t, errors.Is(BadEvidenceError{}, err))
+}
+
+func Test_BadEvidenceError_wrapping(t *testing.T) {
+	err1 := errors.New("error 1")
+	err2 := fmt.Errorf("got error: %w", err1)
+	bee := BadEvidence(err2)
+
+	out := ParseError(errors.New(bee.Error()))
+	assert.True(t, errors.Is(out, bee))
+	assert.True(t, errors.Is(out, err2))
+	assert.True(t, errors.Is(out, err1))
+}

--- a/handler/evidence_rpc.go
+++ b/handler/evidence_rpc.go
@@ -5,10 +5,10 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/rpc"
 
 	"github.com/veraison/ear"
+	"github.com/veraison/services/log"
 	"github.com/veraison/services/plugin"
 	"github.com/veraison/services/proto"
 )
@@ -178,7 +178,7 @@ func (s *RPCClient) GetName() string {
 
 	err := s.client.Call("Plugin.GetName", &unused, &resp)
 	if err != nil {
-		log.Printf("Plugin.GetName RPC call failed: %v", err) // nolint
+		log.Errorf("Plugin.GetName RPC call failed: %v", err) // nolint
 		return ""
 	}
 
@@ -193,7 +193,7 @@ func (s *RPCClient) GetAttestationScheme() string {
 
 	err := s.client.Call("Plugin.GetAttestationScheme", &unused, &resp)
 	if err != nil {
-		log.Printf("Plugin.GetAttestationScheme RPC call failed: %v", err) // nolint
+		log.Errorf("Plugin.GetAttestationScheme RPC call failed: %v", err) // nolint
 		return ""
 	}
 
@@ -209,7 +209,7 @@ func (s *RPCClient) GetSupportedMediaTypes() []string {
 
 	err = s.client.Call("Plugin.GetSupportedMediaTypes", &unused, &resp)
 	if err != nil {
-		log.Printf("Plugin.GetSupportedMediaTypes RPC call failed: %v", err)
+		log.Errorf("Plugin.GetSupportedMediaTypes RPC call failed: %v", err)
 		return nil
 	}
 
@@ -232,6 +232,7 @@ func (s *RPCClient) SynthKeysFromRefValue(tenantID string, swComp *proto.Endorse
 
 	err = s.client.Call("Plugin.SynthKeysFromRefValue", args, &resp)
 	if err != nil {
+		err = ParseError(err)
 		return nil, fmt.Errorf("Plugin.SynthKeysFromRefValue RPC call failed: %w", err) // nolint
 	}
 
@@ -254,6 +255,7 @@ func (s *RPCClient) SynthKeysFromTrustAnchor(tenantID string, ta *proto.Endorsem
 
 	err = s.client.Call("Plugin.SynthKeysFromTrustAnchor", args, &resp)
 	if err != nil {
+		err = ParseError(err)
 		return nil, fmt.Errorf("Plugin.SynthKeysFromTrustAnchor RPC call failed: %w", err) // nolint
 	}
 
@@ -274,6 +276,7 @@ func (s *RPCClient) GetTrustAnchorID(token *proto.AttestationToken) (string, err
 
 	err = s.client.Call("Plugin.GetTrustAnchorID", data, &resp)
 	if err != nil {
+		err = ParseError(err)
 		return "", fmt.Errorf("Plugin.GetTrustAnchorID RPC call failed: %w", err) // nolint
 	}
 
@@ -296,6 +299,7 @@ func (s *RPCClient) ExtractEvidence(token *proto.AttestationToken, trustAnchor s
 
 	err = s.client.Call("Plugin.ExtractEvidence", args, &resp)
 	if err != nil {
+		err = ParseError(err)
 		return nil, fmt.Errorf("Plugin.ExtractEvidence RPC call failed: %w", err) // nolint
 	}
 
@@ -327,7 +331,7 @@ func (s *RPCClient) ValidateEvidenceIntegrity(
 
 	err = s.client.Call("Plugin.ValidateEvidenceIntegrity", args, &resp)
 
-	return err
+	return ParseError(err)
 }
 
 func (s *RPCClient) AppraiseEvidence(ec *proto.EvidenceContext, endorsements []string) (*ear.AttestationResult, error) {
@@ -347,6 +351,7 @@ func (s *RPCClient) AppraiseEvidence(ec *proto.EvidenceContext, endorsements []s
 
 	err = s.client.Call("Plugin.AppraiseEvidence", args, &resp)
 	if err != nil {
+		err = ParseError(err)
 		return nil, fmt.Errorf("Plugin.AppraiseEvidence RPC call failed: %w", err) // nolint
 	}
 
@@ -372,6 +377,7 @@ func (s *RPCClient) ExtractClaims(token *proto.AttestationToken, trustAnchor str
 	var resp []byte
 	err = s.client.Call("Plugin.ExtractClaims", args, &resp)
 	if err != nil {
+		err = ParseError(err)
 		return nil, fmt.Errorf("Plugin.ExtractClaims RPC call failed: %w", err) // nolint
 	}
 

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 .DEFAULT_TARGET: test
 
+# Sets the user for the debug container. Set this to "root" to run  as root
+# (not recommended for actually running tests, but allows you to make one-off
+# modifications to the container's environment (e.g. installing additional
+# tools) before changing to tavern (via "su tavern") to start running tests.
+TEST_USER ?= tavern
+
 SHELL = /bin/bash
 
 THIS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -49,6 +55,7 @@ start-services: $(DEPLOYMENT_SRC_DIR).built/deployment
 debug: .built/image start-services
 	docker container run --rm --interactive  --tty \
 		$(CONTAINER_FLAGS) \
+		--user $(TEST_USER)\
 		--entrypoint /bin/bash \
 		veraison/test
 
@@ -82,7 +89,7 @@ Available targets:
 	test:            run integration tests
 	clean:           remove artefects generated while running integration
 	                 tests
-	debug:           start a shell inside a test runner container
+	debug:           start a shell inside a test runner container.
 	start-services:  start the Veraison services to be tested (this done
 	                 automatically when executing the test target)
 	image:           create the test runner docker image

--- a/integration-tests/data/claims/psa.badinstance.json
+++ b/integration-tests/data/claims/psa.badinstance.json
@@ -1,0 +1,31 @@
+{
+  "eat-profile": "http://arm.com/psa/2.0.0",
+  "psa-client-id": 1,
+  "psa-security-lifecycle": 12288,
+  "psa-implementation-id": "YWNtZS1pbXBsZW1lbnRhdGlvbi1pZC0wMDAwMDAwMDE=",
+  "psa-boot-seed": "3q2+796tvu/erb7v3q2+796tvu/erb7v3q2+796tvu8=",
+  "psa-software-components": [
+    {
+      "measurement-type": "BL",
+      "measurement-value":  "h0KPxSKAPTEGXnvOPPA/5HUJZjHl4Hu9eg/eYMTPJcc=",
+      "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+      "version": "2.1.0"
+    },
+    {
+      "measurement-type": "PRoT",
+      "measurement-value": "AmOCmYm2/ZVPcrqvL8ZLwuLwHWktTecphuqAj26ZgT8=",
+      "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+      "version": "1.3.5"
+    },
+    {
+      "measurement-type": "ARoT",
+      "measurement-value": "o6XnFfDMV0pzw/m+u2vCTzL/1bZ7OHJEwskJ2neaFHg=",
+      "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+      "version": "0.1.4"
+
+    }
+  ],
+  "psa-instance-id":  "Ad6tvu/erb7v3q2+796tvu/erb7v3q2+796tvu/erb7v",
+  "psa-verification-service-indicator": "https://psa-verifier.org",
+  "psa-nonce": "QUp8F0FBs9DpodKK8xUg8NQimf6sQAfe2J1ormzZLxk="
+}

--- a/integration-tests/data/claims/psa.missingclaims.json
+++ b/integration-tests/data/claims/psa.missingclaims.json
@@ -1,0 +1,5 @@
+{
+  "eat-profile": "http://arm.com/psa/2.0.0",
+  "psa-implementation-id": "YWNtZS1pbXBsZW1lbnRhdGlvbi1pZC0wMDAwMDAwMDE=",
+  "psa-instance-id":  "Ac7rrnuJJ6MiflMDz14PH3s0u1Qq1yUKwD+83jbsLxUI"
+}

--- a/integration-tests/data/claims/psa.multinonce.json
+++ b/integration-tests/data/claims/psa.multinonce.json
@@ -1,0 +1,34 @@
+{
+  "eat-profile": "http://arm.com/psa/2.0.0",
+  "psa-client-id": 1,
+  "psa-security-lifecycle": 12288,
+  "psa-nonce": [
+      "YWNtZS1pbXBsZW1lbnRhdGlvbi1pZC0wMDAwMDAwMDE=",
+      "QUp8F0FBs9DpodKK8xUg8NQimf6sQAfe2J1ormzZLxk="
+  ],
+  "psa-implementation-id": "YWNtZS1pbXBsZW1lbnRhdGlvbi1pZC0wMDAwMDAwMDE=",
+  "psa-boot-seed": "3q2+796tvu/erb7v3q2+796tvu/erb7v3q2+796tvu8=",
+  "psa-software-components": [
+    {
+      "measurement-type": "BL",
+      "measurement-value":  "h0KPxSKAPTEGXnvOPPA/5HUJZjHl4Hu9eg/eYMTPJcc=",
+      "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+      "version": "2.1.0"
+    },
+    {
+      "measurement-type": "PRoT",
+      "measurement-value": "AmOCmYm2/ZVPcrqvL8ZLwuLwHWktTecphuqAj26ZgT8=",
+      "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+      "version": "1.3.5"
+    },
+    {
+      "measurement-type": "ARoT",
+      "measurement-value": "o6XnFfDMV0pzw/m+u2vCTzL/1bZ7OHJEwskJ2neaFHg=",
+      "signer-id": "rLsRx+TaIXIFUjzkzhokWuGiOa48a/2eeHH35di66Gs=",
+      "version": "0.1.4"
+
+    }
+  ],
+  "psa-instance-id":  "Ac7rrnuJJ6MiflMDz14PH3s0u1Qq1yUKwD+83jbsLxUI",
+  "psa-verification-service-indicator": "https://psa-verifier.org"
+}

--- a/integration-tests/data/keys/ec.p256.alt.jwk
+++ b/integration-tests/data/keys/ec.p256.alt.jwk
@@ -1,0 +1,1 @@
+{"kty":"EC","crv":"P-256","x":"YYP9TvyY5On5xPPhHeyKXrugffJ9bu0LGDiBqMbPIrQ","y":"msMsvWF8BdDKEoIVWpncXBYmFBf9OxWDD6Naope0EWo","d":"-s6VyD3VOJjCfaFT_YZiUQWx0LL_qINAuCgDoas9MtA"}

--- a/integration-tests/data/results/psa.badcrypto.json
+++ b/integration-tests/data/results/psa.badcrypto.json
@@ -1,0 +1,16 @@
+{
+	"ear.status": "contraindicated",
+	"ear.trustworthiness-vector": {
+		"configuration": 99,
+		"executables": 99,
+		"file-system": 99,
+		"hardware": 99,
+		"instance-identity": 99,
+		"runtime-opaque": 99,
+		"sourced-data": 99,
+		"storage-opaque": 99
+	},
+	"ear.veraison.policy-claims": {
+		"problem": "signature validation failed"
+	}
+}

--- a/integration-tests/data/results/psa.badinstance.json
+++ b/integration-tests/data/results/psa.badinstance.json
@@ -1,0 +1,16 @@
+{
+    "ear.status": "contraindicated",
+    "ear.trustworthiness-vector": {
+        "instance-identity": 99,
+        "configuration": 99,
+        "executables": 99,
+        "file-system": 99,
+        "hardware": 99,
+        "runtime-opaque": 99,
+        "storage-opaque": 99,
+        "sourced-data": 99
+    },
+    "ear.veraison.policy-claims": {
+            "problem": "no trust anchor for evidence"
+    }
+}

--- a/integration-tests/data/results/psa.noident.json
+++ b/integration-tests/data/results/psa.noident.json
@@ -1,0 +1,17 @@
+{
+    "ear.status": "contraindicated",
+    "ear.trustworthiness-vector": {
+        "configuration": 99,
+        "executables": 99,
+        "file-system": 99,
+        "hardware": 99,
+        "instance-identity": 99,
+        "runtime-opaque": 99,
+        "sourced-data": 99,
+        "storage-opaque": 99
+    },
+    "ear.veraison.policy-claims": {
+        "problem": "could not establish identity from evidence"
+    }
+}
+

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -8,6 +8,27 @@ FROM python as veraison-test
 ARG TESTER_UID=1000
 ARG TESTER_GID=1000
 
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+        --assume-yes \
+        --no-install-recommends \
+        less \
+        ruby \
+        jq \
+        vim \
+    && apt-get clean \
+    && apt-get autoremove --assume-yes \
+    && rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/* && \
+    gem install cbor-diag
+
+# Note: unfortunately this does not get packaded as part of the distro (so
+# cannot be installed with apt), and the upstream only provide an amd64 deb, so
+# this will not work on arm64 platforms.
+RUN wget https://dl.step.sm/gh-release/cli/docs-cli-install/v0.23.1/step-cli_0.23.1_amd64.deb && \
+    dpkg -i step-cli_0.23.1_amd64.deb; \
+    rm step-cli_0.23.1_amd64.deb
+
+
 RUN userdel -f $(cat /etc/passwd | awk -F: "\$3 == ${TESTER_UID}" | cut -d: -f1); \
     groupdel -f $(cat /etc/group | awk -F: "\$3 == ${TESTER_GID}" | cut -d: -f1); \
     groupadd -g ${TESTER_GID} tavern && \

--- a/integration-tests/docker/bashrc
+++ b/integration-tests/docker/bashrc
@@ -3,4 +3,11 @@ export PYTHONPATH=$PYTHONPATH:/integration-testing/utils
 export PROVISIONING_HOST=provisioning-service
 export VERIFICATION_HOST=verification-service
 export PS1='\e[0;32m\u@debug-container \e[0;34m\w\n\e[0;32m$\e[0m '
+
 alias ll='ls -lh --color=auto'
+alias jwt='step crypto jwt'
+
+function inspect-result() {
+    local file=$1
+    step crypto jwt inspect --insecure < $file
+}

--- a/integration-tests/tests/common.yaml
+++ b/integration-tests/tests/common.yaml
@@ -16,6 +16,7 @@ variables:
     enacttrust._: application/vnd.enacttrust.tpm-evidence
   keys:
     ec.p256: ec.p256
+    bad: ec.p256.alt
     ec.p256.enacttrust: ec.p256.enacttrust
     ccakeys: [ec.p256, ec.p384]
   endorsements:

--- a/integration-tests/tests/test_end_to_end.tavern.yaml
+++ b/integration-tests/tests/test_end_to_end.tavern.yaml
@@ -65,7 +65,7 @@ stages:
           extra_kwargs:
             scheme: '{scheme}'
             evidence: '{evidence}'
-        - function: checkers:expected_result
+        - function: checkers:compare_to_expected_result
           extra_kwargs:
             expected: data/results/{scheme}.{expected}.json
             verifier_key: data/keys/verifier.jwk
@@ -105,7 +105,7 @@ stages:
     response:
       status_code: 200
       verify_response_with:
-        - function: checkers:expected_result
+        - function: checkers:compare_to_expected_result
           extra_kwargs:
             expected: __generated__/expected/{scheme}.{expected}.server-nonce.json
             verifier_key: data/keys/verifier.jwk

--- a/integration-tests/tests/test_end_to_end.tavern.yaml
+++ b/integration-tests/tests/test_end_to_end.tavern.yaml
@@ -24,6 +24,7 @@ marks:
         - [psa, p1, good, full, ec.p256, good]
         - [psa, p1, good, mini, ec.p256, good]
         - [psa, p1, good, mini, bad, badcrypto]
+        - [psa, p1, badinstance, full, ec.p256, badinstance]
         - [psa, p1, badswcomp, full, ec.p256, badswcomp]
         - [cca, _, good, full, ccakeys, good]
         - [enacttrust, _, good, mini, ec.p256.enacttrust, good]

--- a/integration-tests/tests/test_end_to_end.tavern.yaml
+++ b/integration-tests/tests/test_end_to_end.tavern.yaml
@@ -23,6 +23,7 @@ marks:
       vals:
         - [psa, p1, good, full, ec.p256, good]
         - [psa, p1, good, mini, ec.p256, good]
+        - [psa, p1, good, mini, bad, badcrypto]
         - [psa, p1, badswcomp, full, ec.p256, badswcomp]
         - [cca, _, good, full, ccakeys, good]
         - [enacttrust, _, good, mini, ec.p256.enacttrust, good]

--- a/integration-tests/tests/test_end_to_end.tavern.yaml
+++ b/integration-tests/tests/test_end_to_end.tavern.yaml
@@ -23,6 +23,7 @@ marks:
       vals:
         - [psa, p1, good, full, ec.p256, good]
         - [psa, p1, good, mini, ec.p256, good]
+        - [psa, p1, missingclaims, mini, ec.p256, noident]
         - [psa, p1, good, mini, bad, badcrypto]
         - [psa, p1, badinstance, full, ec.p256, badinstance]
         - [psa, p1, badswcomp, full, ec.p256, badswcomp]

--- a/integration-tests/tests/test_multinonce.tavern.yaml
+++ b/integration-tests/tests/test_multinonce.tavern.yaml
@@ -1,0 +1,74 @@
+test_name: multi-nonce
+
+marks:
+  - parametrize:
+      key:
+        #  Attestation scheme -- this is used to indicate how test cases should
+        #  be constructed (e.g. how the evidence token will be compiled.
+        - scheme
+        # Some attestation schemes (currently, only PSA) may support multiple
+        # profiles. If a scheme does not support multiple profiles, specify it
+        # as '_'.
+        - profile
+        # Which evidence description will be used to construct the evidence token.
+        - evidence
+        # The name of the endorsements spec within common.yaml
+        - endorsements
+        # Signing keys that will be used to construct the evidence. How this is
+        # used is dependent on the scheme.
+        - signing
+        # Expected structure of the returned EAR (EAT (Entity Attestation
+        # Token) Attestation Result).
+        - expected
+      vals:
+        - [psa, p1, multinonce, full, ec.p256, noident]
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: submit post request to the provisioning service successfully
+    request:
+      method: POST
+      url: http://{provisioning-service}/endorsement-provisioning/v1/submit
+      headers:
+        content-type: '{endorsements-content-type}' # set via hook
+      file_body: __generated__/endorsements/endorsements.cbor
+    response:
+      status_code: 200
+
+  - name: verify - creation of session resource
+    request:
+      method: POST
+      url: http://{verification-service}/challenge-response/v1/newSession?nonce={good-nonce}
+    response:
+      status_code: 201
+      save:
+        headers:
+          relying-party-session: Location
+
+  - name: verify - submitting the evidence
+    request:
+      method: POST
+      url: http://{verification-service}/challenge-response/v1/{relying-party-session}
+      headers:
+        content-type: '{evidence-content-type}' # set via hook
+      file_body: __generated__/evidence/{scheme}.{evidence}.cbor
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: checkers:save_result
+          extra_kwargs:
+            scheme: '{scheme}'
+            evidence: '{evidence}'
+        - function: checkers:compare_to_expected_result
+          extra_kwargs:
+            expected: data/results/{scheme}.{expected}.json
+            verifier_key: data/keys/verifier.jwk
+
+  - name: verify as relying party - deleting the session object
+    request:
+      method: DELETE
+      url: http://{verification-service}/challenge-response/v1/{relying-party-session}
+    response:
+      status_code: 204

--- a/integration-tests/utils/checkers.py
+++ b/integration-tests/utils/checkers.py
@@ -45,7 +45,6 @@ def compare_to_expected_result(response, expected, verifier_key):
                 expected_claims["ear.veraison.policy-claims"]
 
 
-
 def _extract_appraisal(response, key_file):
     try:
         result = response.json()["result"]

--- a/integration-tests/utils/generators.py
+++ b/integration-tests/utils/generators.py
@@ -1,9 +1,8 @@
 import ast
 import os
 import shutil
-import subprocess
 
-from util import update_json
+from util import update_json, run_command
 
 
 GENDIR = '__generated__'
@@ -114,9 +113,7 @@ def generate_corim(corim_template, comid_templates, output_path):
         [f'cocli comid create --output-dir={output_dir}'] +
         [f'--template={t}' for t in comid_templates]
     )
-    proc = subprocess.run(comid_create_cmd, shell=True)
-    if proc.returncode:
-        raise RuntimeError(f"Could not generate CoMID(s); cocli returned ({proc.returncode})")
+    run_command(comid_create_cmd, 'generate CoMID(s)')
 
     comid_files = [os.path.join(output_dir, '.'.join([os.path.splitext(name)[0], 'cbor']))
                    for name in map(os.path.basename, comid_templates)]
@@ -125,30 +122,19 @@ def generate_corim(corim_template, comid_templates, output_path):
             [f'cocli corim create --output {output_path} --template={corim_template}'] +
             [f'--comid={cf}' for cf in comid_files]
     )
-    proc = subprocess.run(corim_create_cmd, shell=True)
-    if proc.returncode:
-        raise RuntimeError(f"Could not generate CoRIM; cocli returned ({proc.returncode})")
+    run_command(corim_create_cmd, 'generate CoRIM')
 
 
 def generate_psa_evidence_token(claims_file, key_file, token_file):
-    evcli_command = f"evcli psa create --claims={claims_file} --key={key_file} --token={token_file}"
-    print(evcli_command)
-    proc = subprocess.run(evcli_command, shell=True)
-    if proc.returncode:
-        raise RuntimeError(f"Could not generate PSA token; evcli returned ({proc.returncode})")
+    evcli_command = f"evcli psa create --allow-invalid --claims={claims_file} --key={key_file} --token={token_file}"
+    run_command(evcli_command, 'generate PSA token')
 
 
 def generate_cca_evidence_token(claims_file, pak_file, rak_file, token_file):
     evcli_command = f"evcli cca create --claims={claims_file} " + \
                     f"--pak={pak_file} --rak={rak_file} --token={token_file}"
-    print(evcli_command)
-    proc = subprocess.run(evcli_command, shell=True)
-    if proc.returncode:
-        raise RuntimeError(f"Could not generate PSA token; evcli returned ({proc.returncode})")
+    run_command(evcli_command, 'generate CCA token')
 
 def generate_eancttrust_evidence_token(claims_file, key_file, token_file):
     gentoken_command = f"gen-enacttrust-token -key {key_file} -out {token_file} {claims_file}"
-    print(gentoken_command)
-    proc = subprocess.run(gentoken_command, shell=True)
-    if proc.returncode:
-        raise RuntimeError(f"Could not generate EnactTrust token; gen-token returned ({proc.returncode})")
+    run_command(gentoken_command, 'generate EnactTrust token')

--- a/integration-tests/utils/generators.py
+++ b/integration-tests/utils/generators.py
@@ -106,6 +106,46 @@ def generate_evidence(scheme, evidence, nonce, signing, outname):
         raise ValueError(f'Unexpected scheme: {scheme}')
 
 
+def generate_evidence_from_test_no_nonce(test):
+    scheme = test.test_vars['scheme']
+    evidence = test.test_vars['evidence']
+    signing = test.common_vars['keys'][test.test_vars['signing']]
+    outname = f'{scheme}.{evidence}'
+
+    return generate_evidence_no_nonce(scheme, evidence, signing, outname)
+
+
+def generate_evidence_no_nonce(scheme, evidence, signing, outname):
+    os.makedirs(f'{GENDIR}/evidence', exist_ok=True)
+
+    claims_file = f'data/claims/{scheme}.{evidence}.json'
+
+    if scheme == 'psa':
+        iak = signing
+        generate_psa_evidence_token(
+                claims_file,
+                f'data/keys/{iak}.jwk',
+                f'{GENDIR}/evidence/{outname}.cbor',
+                )
+    elif scheme == 'cca':
+        pak, rak = signing
+        generate_cca_evidence_token(
+                claims_file,
+                f'data/keys/{pak}.jwk',
+                f'data/keys/{rak}.jwk',
+                f'{GENDIR}/evidence/{outname}.cbor',
+                )
+    elif scheme == 'enacttrust':
+        key = signing
+        generate_eancttrust_evidence_token(
+                claims_file,
+                f'data/keys/{key}.pem',
+                f'{GENDIR}/evidence/{outname}.cbor',
+                )
+    else:
+        raise ValueError(f'Unexpected scheme: {scheme}')
+
+
 def generate_corim(corim_template, comid_templates, output_path):
     output_dir = os.path.dirname(output_path)
 

--- a/integration-tests/utils/hooks.py
+++ b/integration-tests/utils/hooks.py
@@ -16,6 +16,13 @@ def setup_bad_session(test, veriables):
 def setup_no_nonce(test, veriables):
     generate_evidence_from_test(test)
 
+
+def setup_multi_nonce(test, variables):
+    _set_content_types(test, variables)
+    generate_endorsements(test)
+    generate_evidence_from_test_no_nonce(test)
+
+
 def _set_content_types(test, variables):
     scheme = test.test_vars['scheme']
     profile = test.test_vars['profile']

--- a/integration-tests/utils/util.py
+++ b/integration-tests/utils/util.py
@@ -1,5 +1,6 @@
 import json
 import re
+import subprocess
 
 
 def to_identifier(text):
@@ -19,6 +20,8 @@ def update_json(infile, new_data, outfile):
 def update_dict(base, other):
     for k, ov in other.items():
         bv = base.get(k)
+        if bv is None:
+            continue  # nothing to update
 
         if isinstance(bv, dict) and isinstance(ov, dict):
             update_dict(bv, ov)
@@ -27,4 +30,14 @@ def update_dict(base, other):
         else:
             base[k] = ov
 
+
+def run_command(command: str, action: str) -> int:
+    print(command)
+    proc = subprocess.run(command, capture_output=True, shell=True)
+    print(f'---STDOUT---\n{proc.stdout}')
+    print(f'---STDERR---\n{proc.stderr}')
+    print(f'------------')
+    if proc.returncode:
+        executable = command.split()[0]
+        raise RuntimeError(f'Could not {action}; {executable} returned {proc.returncode}')
 

--- a/scheme/cca-ssd-platform/evidence_handler.go
+++ b/scheme/cca-ssd-platform/evidence_handler.go
@@ -139,7 +139,7 @@ func (s EvidenceHandler) GetTrustAnchorID(token *proto.AttestationToken) (string
 
 	err := ccaToken.FromCBOR(token.Data)
 	if err != nil {
-		return "", err
+		return "", handler.BadEvidence(err)
 	}
 
 	return ccaTaLookupKey(
@@ -157,14 +157,14 @@ func (s EvidenceHandler) ExtractClaims(
 	var ccaToken ccatoken.Evidence
 
 	if err := ccaToken.FromCBOR(token.Data); err != nil {
-		return nil, err
+		return nil, handler.BadEvidence(err)
 	}
 
 	var extracted handler.ExtractedClaims
 
 	claimsSet, err := claimsToMap(ccaToken.PlatformClaims)
 	if err != nil {
-		return nil, err
+		return nil, handler.BadEvidence(err)
 	}
 
 	extracted.ClaimsSet = claimsSet
@@ -214,11 +214,11 @@ func (s EvidenceHandler) ValidateEvidenceIntegrity(
 	var ccaToken ccatoken.Evidence
 
 	if err = ccaToken.FromCBOR(token.Data); err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 
 	if err = ccaToken.Verify(pk); err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 	log.Debug("CCA platform token signature, realm token signature and cryptographic binding verified")
 	return nil
@@ -291,7 +291,7 @@ func populateAttestationResult(
 
 	rawLifeCycle, err := claims.GetSecurityLifeCycle()
 	if err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 
 	lifeCycle := psatoken.CcaLifeCycleToState(rawLifeCycle)

--- a/scheme/psa-iot/evidence_handler.go
+++ b/scheme/psa-iot/evidence_handler.go
@@ -129,7 +129,7 @@ func (s EvidenceHandler) GetTrustAnchorID(token *proto.AttestationToken) (string
 
 	err := psaToken.FromCOSE(token.Data)
 	if err != nil {
-		return "", err
+		return "", handler.BadEvidence(err)
 	}
 
 	return psaTaLookupKey(
@@ -146,14 +146,14 @@ func (s EvidenceHandler) ExtractClaims(
 	var psaToken psatoken.Evidence
 
 	if err := psaToken.FromCOSE(token.Data); err != nil {
-		return nil, err
+		return nil, handler.BadEvidence(err)
 	}
 
 	var extracted handler.ExtractedClaims
 
 	claimsSet, err := claimsToMap(psaToken.Claims)
 	if err != nil {
-		return nil, err
+		return nil, handler.BadEvidence(err)
 	}
 	extracted.ClaimsSet = claimsSet
 
@@ -200,11 +200,11 @@ func (s EvidenceHandler) ValidateEvidenceIntegrity(
 	var psaToken psatoken.Evidence
 
 	if err = psaToken.FromCOSE(token.Data); err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 
 	if err = psaToken.Verify(pk); err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 	log.Println("\n Token Signature Verified")
 	return nil
@@ -260,7 +260,7 @@ func populateAttestationResult(
 ) error {
 	claims, err := mapToClaims(evidence)
 	if err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 
 	appraisal := result.Submods[SchemeName]
@@ -271,7 +271,7 @@ func populateAttestationResult(
 
 	rawLifeCycle, err := claims.GetSecurityLifeCycle()
 	if err != nil {
-		return err
+		return handler.BadEvidence(err)
 	}
 
 	lifeCycle := psatoken.PsaLifeCycleToState(rawLifeCycle)

--- a/scheme/tcg-dice/evidence_handler.go
+++ b/scheme/tcg-dice/evidence_handler.go
@@ -58,7 +58,7 @@ func (s EvidenceHandler) ExtractClaims(
 
 	aliasCert, err := parseTokenCerts(token.Data, intermediates, roots)
 	if err != nil {
-		return nil, err
+		return nil, handler.BadEvidence(err)
 	}
 
 	opts := x509.VerifyOptions{
@@ -69,13 +69,14 @@ func (s EvidenceHandler) ExtractClaims(
 
 	claims, err := extractEvidenceClaims(aliasCert)
 	if err != nil {
-		return nil, err
+		return nil, handler.BadEvidence(err)
 	}
 
 	// note: must verify this after extracting claims so that the Subject Alternative Name
 	// gets processed; otherwise, it will be raised an unhandled critical extension.
 	if _, err = aliasCert.Verify(opts); err != nil {
-		return nil, errors.New("failed to verify alias cert: " + err.Error())
+		return nil, handler.BadEvidence(
+			"failed to verify alias cert: " + err.Error())
 	}
 
 	extracted := handler.ExtractedClaims{
@@ -83,7 +84,7 @@ func (s EvidenceHandler) ExtractClaims(
 		ReferenceID: "dice://",
 	}
 
-	return &extracted, err
+	return &extracted, nil
 }
 
 func (s EvidenceHandler) ValidateEvidenceIntegrity(

--- a/scripts/extract-evidence-claims
+++ b/scripts/extract-evidence-claims
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script is used to extract the claims structure (serialized CBOR) from COSE tokens.
+# On Arch, you need in stall yq and ruby-cbor-diag (AUR) packages.
+# On Ubuntu, install cbor-diag gem; yq seems to only be available via *shudder* snap...
+cbor2yaml.rb $1 | yq .value[2] | tr -d \" | base64 -d

--- a/verification/api/handler_test.go
+++ b/verification/api/handler_test.go
@@ -47,19 +47,11 @@ var (
 		"application/psa-attestation-token"
 	]
 }`
-	testFailedSession = `{
-	"status": "failed",
-	"nonce": "mVubqtg3Wa5GSrx3L/2B99cQU2bMQFVYUI9aTmDYi64=",
-	"expiry": "2022-07-13T13:50:24.520525+01:00",
-	"accept": [
-		"application/eat_cwt;profile=http://arm.com/psa/2.0.0",
-		"application/eat_cwt;profile=PSA_IOT_PROFILE_1",
-		"application/psa-attestation-token"
-	],
-	"evidence": {
-		"type":"application/eat_cwt; profile=http://arm.com/psa/2.0.0",
-		"value":"eyAiayI6ICJ2IiB9"
-	}
+	testFailedProblem = `{
+	"type": "about:blank",
+	"title": "Internal Server Error",
+	"status": 500,
+	"detail": "error encountered while processing evidence"
 }`
 	testProcessingSession = `{
 	"status": "processing",
@@ -585,9 +577,9 @@ func TestHandler_SubmitEvidence_process_evidence_failed(t *testing.T) {
 
 	vmErr := "enqueueing evidence failed"
 
-	expectedCode := http.StatusOK
-	expectedType := ChallengeResponseSessionMediaType
-	expectedBody := testFailedSession
+	expectedCode := http.StatusInternalServerError
+	expectedType := "application/problem+json"
+	expectedBody := testFailedProblem
 
 	sm := mock_deps.NewMockISessionManager(ctrl)
 	sm.EXPECT().

--- a/verification/cmd/verification-service/config.yaml
+++ b/verification/cmd/verification-service/config.yaml
@@ -2,8 +2,8 @@
 # from the docker deployment debug shell.
 logging:
   level: debug  # valid levels: error, warning, info, debug
-provisioning:
-  listen-addr: 0.0.0.0:8888
+verification:
+  listen-addr: 0.0.0.0:8080
 vts:
   server-addr: vts-service:50051
 # vim: set ft=yaml:


### PR DESCRIPTION
Ensure correct handing of various errors in the provided evidence during verification. The general idea is that problems with the service setup should be communicted as errors (ultimately resulting in a 500 response from the REST frontend), while problems with the evidence should be communicated via an appropriately composed attestation result (with in a 200 response from the frontend).

This is done by creating an error type specifically to indicate bad evidnece, and handling it differently from others. Liminations in how errors can be represented in AR4SI are mitegated by providing additional information a a "problem" policy claim.