### PR TITLE
Add a warning RE the use of sqlite3 in deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ The `veraison` command allows starting and stopping `veraison` services and
 viewing and manipulating Veraison logs and stores. See the output of `veraison
 -h` for the full list of available commands.
 
+> **Warning**: The docker deployment is not suitable for production. It is only
+> intended to be used in development environments. It is not hardened and
+> cannot handle high traffic volumes.
+
+
 ### End-to-end example
 
 An example of an end-to-end provisioning and verification flow exists

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -67,6 +67,11 @@ The deployment may be configured by changing the settings inside
 [deployment.cfg](./deployment.cfg). See the comments inside that file for the
 explanation of the individual configuration values.
 
+> **Note**: The individual services rely on configuration inside
+> `config.yaml.template`. This currently uses the `sqlite3` driver for the
+> store backend, which limits request throughput and makes the deployment
+> unsuitable for production or performance testing (for the latter, one can
+> modify the template to use `memory` backend for the stores).
 
 ### `make` Options
 

--- a/kvstore/README.md
+++ b/kvstore/README.md
@@ -46,6 +46,9 @@ Currently, `memory` backend does not support any configuration.
 
 ### `sql` backend configuration
 
+> **Note**: `sqlite3`, the default driver for the backend, is unsuitable for
+> production or performance testing.
+
 `driver`: The name of the golang SQL driver to use ([see here](https://github.com/golang/go/wiki/SQLDrivers))
 - `datasource`: Data source name to use. The format of the name depends on the
   driver (e.g. a file path for SQLite or server dial string for PostgreSQL).

--- a/perf/reports/report-2023-05.md
+++ b/perf/reports/report-2023-05.md
@@ -1,0 +1,85 @@
+# Veraison perf evaluation 2023-05-03
+
+## Method
+
+- Loads are generated using [`locust`](https://locust.io/), with a duration of 30 seconds.
+- The same static payloads (PSA evidence and endorsements taken from
+  integration tests) are used for each request.
+- Request handling times extracted from `gin` logs. Error bars on request times
+  are the 95% conf. int.
+- Error counts are for responses with statuses other than `2xx`.
+- Execution and analysis scripts under `perf/` inside `services` repo
+  (currently only `setrofim-perf` branch).
+
+---
+
+## Results
+
+### Initial
+
+#### Provisioning
+
+![height:500px center](../notebooks/figs/prov-stats-adrenaline-plug-sql.png)
+
+#### Verification
+
+![height:500px center](../notebooks/figs/verif-stats-adrenaline-plug-sql.png)
+
+#### Well Known (control)
+
+![height:500px center](../notebooks/figs/wellknown-stats-adrenaline-plug-sql.png)
+
+
+There is a lot of weirdness happening, but the primary observation is the
+increase in the number of errors as the load increases. The Errors are all of
+the form
+
+```
+api-handler	rpc error: code = Unknown desc = database is locked
+api	problem encountered	{"title": "Internal Server Error", "detail": "error encountered while processing evidence"}
+```
+
+Looking at the VTS logs, the root cause appears to be
+
+```
+ {"detail":["signature verification failed: verification error","verification error"],"detail-type":"error","error":"bad evidence"}
+```
+
+Which suggested that the issue is with the sqlite3 database, which is
+used as the backend for the K-V store.
+
+### Memory Backend
+
+To confirm this, the tests were re-run against a deployment configured to use
+the `memory` backend for the K-V store (i.e. stored items are kept in memory
+and are not persisted to disk).
+
+#### Provisioning
+
+![height:500px center](../notebooks/figs/prov-stats-adrenaline-plug-mem.png)
+
+#### Verification
+
+![height:500px center](../notebooks/figs/verif-stats-adrenaline-plug-mem.png)
+
+#### Well Known (control)
+
+![height:500px center](../notebooks/figs/wellknown-stats-adrenaline-plug-mem.png)
+
+This produces the expected linear progression as the number of active users
+increases.
+
+---
+
+## Conclusion
+
+- The K-V store is the bottleneck for most operations.
+- Since the verification path performs more store accesses per request than the
+  provisioning path, it is more heavily impacted.
+- sqlite3 is wholly unsuitable as the K-V store backend in a production
+  setting.
+- The deployment implementation and configuration is likely to be more
+  impactful on service performance than the actual Veraison code.
+  - To put another way: we do not appear to have any major perf issues in our
+    code that require immediately addressing; optimisation efforts are best
+    spent on deployment configuration.


### PR DESCRIPTION
Add a warning about the default deployment not being suitable for performance testing due to the use of sqlite3.