### PR TITLE
minimal command line treatment for services

### DIFF
--- a/config/cmdline.go
+++ b/config/cmdline.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package config
+
+import (
+	"fmt"
+	"os"
+
+	flag "github.com/spf13/pflag"
+)
+
+// Veraison services common command line flags:
+// -c, --config <configuration-file> (default "config.yaml")
+// -h, --help
+// -v, --version
+var (
+	DisplayVersion *bool   = flag.BoolP("version", "v", false, "print version and exit")
+	DisplayHelp    *bool   = flag.BoolP("help", "h", false, "print help and exit")
+	File           *string = flag.StringP("config", "c", "config.yaml", "configuration file")
+)
+
+// CmdLine parses the command line an
+func CmdLine() {
+	flag.Parse()
+
+	if *DisplayVersion {
+		fmt.Printf("%v\n", Version)
+		os.Exit(0)
+	}
+
+	if *DisplayHelp {
+		flag.Usage()
+		os.Exit(0)
+	}
+}

--- a/config/viper.go
+++ b/config/viper.go
@@ -13,11 +13,11 @@ import (
 
 // ReadRawConfig instantiates a Viper and uses it to read in configuration. If
 // path is specified as something other than an empty string, Viper will
-// attempt to read it, infrering the format from the file extension. Otherwise,
+// attempt to read it, inferring the format from the file extension. Otherwise,
 // it will for a file called "config.yaml" inside current working directory. An
 // error will be returned if there are problems reading configuration. Unless
 // allowNotFount is set to true, this includes the config file (either the
-// explicitly specfied one or the implicit config.yaml) not being present.
+// explicitly specified one or the implicit config.yaml) not being present.
 func ReadRawConfig(path string, allowNotFound bool) (*viper.Viper, error) {
 	v := viper.New()
 

--- a/provisioning/cmd/provisioning-service/main.go
+++ b/provisioning/cmd/provisioning-service/main.go
@@ -28,7 +28,9 @@ type cfg struct {
 }
 
 func main() {
-	v, err := config.ReadRawConfig("", false)
+	config.CmdLine()
+
+	v, err := config.ReadRawConfig(*config.File, false)
 	if err != nil {
 		log.Fatalf("Could not read config sources: %v", err)
 	}

--- a/verification/cmd/verification-service/main.go
+++ b/verification/cmd/verification-service/main.go
@@ -23,7 +23,9 @@ type cfg struct {
 }
 
 func main() {
-	v, err := config.ReadRawConfig("", true)
+	config.CmdLine()
+
+	v, err := config.ReadRawConfig(*config.File, false)
 	if err != nil {
 		log.Fatalf("Could not read config: %v", err)
 	}

--- a/vts/cmd/vts-service/main.go
+++ b/vts/cmd/vts-service/main.go
@@ -23,7 +23,9 @@ import (
 )
 
 func main() {
-	v, err := config.ReadRawConfig("", false)
+	config.CmdLine()
+
+	v, err := config.ReadRawConfig(*config.File, false)
 	if err != nil {
 		log.Fatalf("could not read config: %v", err)
 	}


### PR DESCRIPTION
enable the following cmd line switches for all services:
```
-c, --config <configuration-file> (default "config.yaml")
-h, --help
-v, --version
```