### PR TITLE
Parsec TPM plugin: fix encoding of the `akpub` claim

### DIFF
--- a/scheme/parsec-tpm/evidence_handler.go
+++ b/scheme/parsec-tpm/evidence_handler.go
@@ -277,7 +277,7 @@ func populateAttestationResult(
 	if err != nil {
 		return fmt.Errorf("unable to marshal public key: %w", err)
 	}
-	pubkey := base64.StdEncoding.EncodeToString(kd)
+	pubkey := base64.RawURLEncoding.EncodeToString(kd)
 	appraisal.AppraisalExtensions.VeraisonKeyAttestation = &map[string]interface{}{
 		"akpub": pubkey,
 	}


### PR DESCRIPTION
Needs to be Base64 URL-safe w/out padding