### PR TITLE
enacttrust fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ deployments/docker/.bin
 integration-tests/.built
 __generated__
 __pycache__
-__debug_bin
+__debug_bin*
 management/cmd/management-service/management-service
 
 # Test binary, built with `go test -c`
@@ -34,3 +34,4 @@ management/cmd/management-service/management-service
 tags
 
 .ipynb_checkpoints
+

--- a/builtin/builtin_loader.go
+++ b/builtin/builtin_loader.go
@@ -25,7 +25,7 @@ func NewBuiltinLoader(logger *zap.SugaredLogger) *BuiltinLoader {
 	return &BuiltinLoader{logger: logger}
 }
 
-func CreateBultinLoader(
+func CreateBuiltinLoader(
 	cfg map[string]interface{},
 	logger *zap.SugaredLogger,
 ) (*BuiltinLoader, error) {
@@ -58,6 +58,11 @@ func DiscoverBuiltin[I plugin.IPluggable]() error {
 
 func DiscoverBuiltinUsing[I plugin.IPluggable](loader *BuiltinLoader) error {
 	for _, p := range plugins {
+		_, ok := p.(I)
+		if !ok {
+			continue
+		}
+
 		name := p.GetName()
 		if _, ok := loader.loadedByName[name]; ok {
 			loader.logger.Panicw("duplicate plugin name", "name", name)

--- a/builtin/builtin_manager.go
+++ b/builtin/builtin_manager.go
@@ -31,7 +31,7 @@ func CreateBuiltinManager[I plugin.IPluggable](
 		return nil, err
 	}
 
-	loader, err := CreateBultinLoader(subs["builtin"].AllSettings(), logger)
+	loader, err := CreateBuiltinLoader(subs["builtin"].AllSettings(), logger)
 	if err != nil {
 		return nil, err
 	}

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -129,6 +129,10 @@ hostname of the VTS service we just stopped, so that the provisioning and
 verification services that are still running will now talk to our debug container
 instead.
 
+(Note: if you were replacing a REST service, rather than VTS, you would also
+set the `DEBUG_PORT` variable to the value appropriate to the service (see
+[deployment.cfg](./deployment.cfg).)
+
 Next, navigate to the location of the VTS service executable (keeping in mind
 that the root of the repo is mapped to `/veraison/build` inside the container),
 and start the debugger:

--- a/integration-tests/data/claims/enacttrust.badnode.json
+++ b/integration-tests/data/claims/enacttrust.badnode.json
@@ -1,0 +1,7 @@
+{
+	"node-id": "7df7714e-aa04-4638-bcbf-434b1dd720f1",
+	"firmware": 7,
+	"pcrs": [1, 2, 3, 4],
+	"algorithm": 11,
+	"digest": "h0KPxSKAPTEGXnvOPPA/5HUJZjHl4Hu9eg/eYMTPJcc="
+}

--- a/integration-tests/data/endorsements/comid-enacttrust-badta.json
+++ b/integration-tests/data/endorsements/comid-enacttrust-badta.json
@@ -1,0 +1,33 @@
+{
+  "tag-identity": {
+    "id": "00000000-0000-0000-0000-000000000000"
+  },
+  "entities": [
+    {
+      "name": "EnactTrust",
+      "regid": "https://enacttrust.com",
+      "roles": [
+        "tagCreator",
+        "creator",
+        "maintainer"
+      ]
+    }
+  ],
+  "triples": {
+    "attester-verification-keys": [
+      {
+        "environment": {
+          "instance": {
+            "type": "uuid",
+            "value": "7df7714e-aa04-4638-bcbf-434b1dd720f1"
+          }
+        },
+        "verification-keys": [
+          {
+            "key": "@@@@"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integration-tests/data/results/enacttrust.badnode.json
+++ b/integration-tests/data/results/enacttrust.badnode.json
@@ -1,0 +1,17 @@
+{
+    "ear.status": "contraindicated",
+    "ear.trustworthiness-vector": {
+        "configuration": 99,
+        "executables": 99,
+        "file-system": 99,
+        "hardware": 99,
+        "instance-identity": 99,
+        "runtime-opaque": 99,
+        "sourced-data": 99,
+        "storage-opaque": 99
+    },
+    "ear.appraisal-policy-id": "policy:TPM_ENACTTRUST",
+    "ear.veraison.policy-claims": {
+        "problem": "could not establish identity from evidence"
+    }
+}

--- a/integration-tests/tests/common.yaml
+++ b/integration-tests/tests/common.yaml
@@ -28,3 +28,4 @@ variables:
     # ../data/endorsements/README.md). The CoRIM name is the first one in the list.
     full: [full, ta, refval]
     mini: [mini, ta, refval]
+    mini-bad: [mini, badta]

--- a/integration-tests/tests/test_enacttrust_badkey.tavern.yaml
+++ b/integration-tests/tests/test_enacttrust_badkey.tavern.yaml
@@ -1,0 +1,38 @@
+test_name: enacttrust-badkey
+
+marks:
+  - parametrize:
+      key:
+        #  Attestation scheme -- this is used to indicate how test cases should
+        #  be constructed (e.g. how the evidence token will be compiled.
+        - scheme
+        # Some attestation schemes (currently, only PSA) may support multiple
+        # profiles. If a scheme does not support multiple profiles, specify it
+        # as '_'.
+        - profile
+        # The name of the endorsements spec within common.yaml
+        - endorsements
+        # Signing keys that will be used to construct the evidence. How this is
+        # used is dependent on the scheme.
+        - signing
+      vals:
+        - [enacttrust, _, mini-bad, ec.p256.enacttrust]
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: submit post request to the provisioning service successfully
+    request:
+      method: POST
+      url: http://{provisioning-service}/endorsement-provisioning/v1/submit
+      headers:
+        content-type: '{endorsements-content-type}' # set via hook
+      file_body: __generated__/endorsements/corim-{scheme}-{endorsements}.cbor
+    response:
+      status_code: 200
+      json:
+        status: failed
+        failure-reason: 'submit endorsement returned error: submit endorsements failed: RPC server returned error: plugin "unsigned-corim (TPM EnactTrust profile)" returned error: bad key in CoMID at index 0: could not base64-decode ak-pub: illegal base64 data at input byte 0'
+        # NOTE: the commented version below is for builtin plugins.
+        #failure-reason: 'submit endorsement returned error: submit endorsements failed: bad key in CoMID at index 0: could not base64-decode ak-pub: illegal base64 data at input byte 0'

--- a/integration-tests/tests/test_enacttrust_badnode.tavern.yaml
+++ b/integration-tests/tests/test_enacttrust_badnode.tavern.yaml
@@ -1,0 +1,74 @@
+test_name: enacttrust-badnode
+
+marks:
+  - parametrize:
+      key:
+        #  Attestation scheme -- this is used to indicate how test cases should
+        #  be constructed (e.g. how the evidence token will be compiled.
+        - scheme
+        # Some attestation schemes (currently, only PSA) may support multiple
+        # profiles. If a scheme does not support multiple profiles, specify it
+        # as '_'.
+        - profile
+        # Which evidence description will be used to construct the evidence token.
+        - evidence
+        # The name of the endorsements spec within common.yaml
+        - endorsements
+        # Signing keys that will be used to construct the evidence. How this is
+        # used is dependent on the scheme.
+        - signing
+        # Expected structure of the returned EAR (EAT (Entity Attestation
+        # Token) Attestation Result).
+        - expected
+      vals:
+        - [enacttrust, _, badnode, mini, ec.p256.enacttrust, badnode]
+
+includes:
+  - !include common.yaml
+
+stages:
+  - name: submit post request to the provisioning service successfully
+    request:
+      method: POST
+      url: http://{provisioning-service}/endorsement-provisioning/v1/submit
+      headers:
+        content-type: '{endorsements-content-type}' # set via hook
+      file_body: __generated__/endorsements/corim-{scheme}-{endorsements}.cbor
+    response:
+      status_code: 200
+
+  - name: verify as relying party - creation of session resource
+    request:
+      method: POST
+      url: http://{verification-service}/challenge-response/v1/newSession?nonce={good-nonce}
+    response:
+      status_code: 201
+      save:
+        headers:
+          relying-party-session: Location
+
+  - name: verify as relying party - submitting the evidence
+    request:
+      method: POST
+      url: http://{verification-service}/challenge-response/v1/{relying-party-session}
+      headers:
+        content-type: '{evidence-content-type}' # set via hook
+      file_body: __generated__/evidence/{scheme}.{evidence}.cbor
+    response:
+      status_code: 200
+      verify_response_with:
+        - function: checkers:save_result
+          extra_kwargs:
+            scheme: '{scheme}'
+            evidence: '{evidence}'
+        - function: checkers:compare_to_expected_result
+          extra_kwargs:
+            expected: data/results/{scheme}.{expected}.json
+            verifier_key: data/keys/verifier.jwk
+
+  - name: verify as relying party - deleting the session object
+    request:
+      method: DELETE
+      url: http://{verification-service}/challenge-response/v1/{relying-party-session}
+    response:
+      status_code: 204

--- a/integration-tests/utils/generators.py
+++ b/integration-tests/utils/generators.py
@@ -97,10 +97,12 @@ def generate_evidence(scheme, evidence, nonce, signing, outname):
                 )
     elif scheme == 'enacttrust':
         key = signing
-        generate_eancttrust_evidence_token(
+        badnode = True if 'badnode' in evidence else False
+        generate_enacttrust_evidence_token(
                 claims_file,
                 f'data/keys/{key}.pem',
                 f'{GENDIR}/evidence/{outname}.cbor',
+                badnode,
                 )
     else:
         raise ValueError(f'Unexpected scheme: {scheme}')
@@ -137,7 +139,7 @@ def generate_evidence_no_nonce(scheme, evidence, signing, outname):
                 )
     elif scheme == 'enacttrust':
         key = signing
-        generate_eancttrust_evidence_token(
+        generate_enacttrust_evidence_token(
                 claims_file,
                 f'data/keys/{key}.pem',
                 f'{GENDIR}/evidence/{outname}.cbor',
@@ -175,6 +177,7 @@ def generate_cca_evidence_token(claims_file, iak_file, rak_file, token_file):
                     f"--iak={iak_file} --rak={rak_file} --token={token_file}"
     run_command(evcli_command, 'generate CCA token')
 
-def generate_eancttrust_evidence_token(claims_file, key_file, token_file):
-    gentoken_command = f"gen-enacttrust-token -key {key_file} -out {token_file} {claims_file}"
+def generate_enacttrust_evidence_token(claims_file, key_file, token_file, badnode):
+    bn_flag = '-bad-node' if badnode else ''
+    gentoken_command = f"gen-enacttrust-token {bn_flag} -key {key_file} -out {token_file} {claims_file}"
     run_command(gentoken_command, 'generate EnactTrust token')

--- a/integration-tests/utils/generators.py
+++ b/integration-tests/utils/generators.py
@@ -15,13 +15,16 @@ def generate_endorsements(test):
     spec = test.test_vars['endorsements']
 
     if isinstance(spec, str):
+        tag = spec
         spec = test.common_vars['endorsements'][spec]
+    else:
+        tag = spec[0]
 
     corim_template_name = 'corim-{}-{}.json'.format(scheme, spec[0])
     corim_template = f'data/endorsements/{corim_template_name}'
     comid_templates = ['data/endorsements/comid-{}-{}.json'.format(scheme, c)
                        for c in spec[1:]]
-    output_path = f'{GENDIR}/endorsements/corim-{scheme}-{spec[0]}.cbor'
+    output_path = f'{GENDIR}/endorsements/corim-{scheme}-{tag}.cbor'
 
     generate_corim(corim_template, comid_templates, output_path)
 

--- a/integration-tests/utils/hooks.py
+++ b/integration-tests/utils/hooks.py
@@ -29,6 +29,10 @@ def setup_enacttrust_badnode(test, variables):
     generate_endorsements(test)
     generate_evidence_from_test(test)
 
+def setup_enacttrust_badkey(test, variables):
+    _set_content_types(test, variables)
+    generate_endorsements(test)
+
 
 def _set_content_types(test, variables):
     scheme = test.test_vars['scheme']

--- a/integration-tests/utils/hooks.py
+++ b/integration-tests/utils/hooks.py
@@ -24,6 +24,12 @@ def setup_multi_nonce(test, variables):
     generate_evidence_from_test_no_nonce(test)
 
 
+def setup_enacttrust_badnode(test, variables):
+    _set_content_types(test, variables)
+    generate_endorsements(test)
+    generate_evidence_from_test(test)
+
+
 def _set_content_types(test, variables):
     scheme = test.test_vars['scheme']
     profile = test.test_vars['profile']

--- a/scheme/tpm-enacttrust/evidence_handler.go
+++ b/scheme/tpm-enacttrust/evidence_handler.go
@@ -65,7 +65,7 @@ func (s EvidenceHandler) GetTrustAnchorID(token *proto.AttestationToken) (string
 	var decoded Token
 
 	if err := decoded.Decode(token.Data); err != nil {
-		return "", err
+		return "", handler.BadEvidence(err)
 	}
 
 	return tpmEnactTrustLookupKey(token.TenantId, decoded.NodeId.String()), nil
@@ -84,7 +84,7 @@ func (s EvidenceHandler) ExtractClaims(
 	}
 
 	if !supported {
-		return nil, fmt.Errorf("wrong media type: expect %q, but found %q",
+		return nil, handler.BadEvidence("wrong media type: expect %q, but found %q",
 			strings.Join(EvidenceMediaTypes, ", "),
 			token.MediaType,
 		)
@@ -93,11 +93,11 @@ func (s EvidenceHandler) ExtractClaims(
 	var decoded Token
 
 	if err := decoded.Decode(token.Data); err != nil {
-		return nil, fmt.Errorf("could not decode token: %w", err)
+		return nil, handler.BadEvidence("could not decode token: %w", err)
 	}
 
 	if decoded.AttestationData.Type != tpm2.TagAttestQuote {
-		return nil, fmt.Errorf("wrong TPMS_ATTEST type: want %d, got %d",
+		return nil, handler.BadEvidence("wrong TPMS_ATTEST type: want %d, got %d",
 			tpm2.TagAttestQuote, decoded.AttestationData.Type)
 	}
 

--- a/scheme/tpm-enacttrust/test/cmd/gen-token/README.md
+++ b/scheme/tpm-enacttrust/test/cmd/gen-token/README.md
@@ -11,12 +11,12 @@ An attestation token has the following format:
 
 where
 
-`NODE_ID` is the UUID of the attsting node, `TPMS_ATTEST_LEN` is a uint16
-values containing the length (in bytes) of the following `TPMS_ATTEST`
+`NODE_ID` is the 16 byte UUID of the attesting node, `TPMS_ATTEST_LEN` is a
+uint16 value containing the length (in bytes) of the following `TPMS_ATTEST`
 structure. `TPMS_ATTEST` is structured according to
 [TPM 2.0
 Specification](https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part2_Structures_pub.pdf).
-`TPMS_ATTEST_SIGNATURE` is the ECDSA signature of the `TPMS_ATTEST` structure.
+`TPMS_ATTEST_SIGNATURE` is the ES256 signature of the `TPMS_ATTEST` structure.
 
 ## Token Payload Description Format
 

--- a/vts/cmd/vts-service/main.go
+++ b/vts/cmd/vts-service/main.go
@@ -67,7 +67,7 @@ func main() {
 	var evPluginManager plugin.IManager[handler.IEvidenceHandler]
 	var endPluginManager plugin.IManager[handler.IEndorsementHandler]
 
-	psubs, err := config.GetSubs(subs["plugin"], "go-plugin")
+	psubs, err := config.GetSubs(subs["plugin"], "*go-plugin", "*builtin")
 	if err != nil {
 		log.Fatalf("could not get subs: %v", err)
 	}
@@ -96,7 +96,7 @@ func main() {
 			log.Fatalf("could not create endorsement PluginManagerWithLoader: %v", err)
 		}
 	} else if config.SchemeLoader == "builtin" {
-		loader, err := builtin.CreateBultinLoader(
+		loader, err := builtin.CreateBuiltinLoader(
 			psubs["builtin"].AllSettings(),
 			log.Named("builtin"))
 		if err != nil {


### PR DESCRIPTION
Fixes for a number of issues identified while debugging enacttrust attestation scheme. As well as fixes to the enacttrust scheme, and some minor typo/doc updates, this incudes fixes to the builtin plugin loader (that became broken when the endorsement decoder plugins were moved from `provisioning` to `vts`).