### PR TITLE
scheme/tpm-enacttrust: fix failed attestation result

### DIFF
--- a/scheme/tpm-enacttrust/evidence_handler.go
+++ b/scheme/tpm-enacttrust/evidence_handler.go
@@ -175,6 +175,9 @@ func (s EvidenceHandler) AppraiseEvidence(
 	if endorsements.Digest == evidenceDigest {
 		appraisal.TrustVector.Executables = ear.ApprovedRuntimeClaim
 		*appraisal.Status = ear.TrustTierAffirming
+	} else {
+		appraisal.TrustVector.Executables = ear.UnrecognizedRuntimeClaim
+		*appraisal.Status = ear.TrustTierContraindicated
 	}
 
 	return result, nil


### PR DESCRIPTION
Evidence processing is checking that the hash in the evidence matches the provisioned reference value, and sets status to affirming if it does.

However, prior to this, it was not doing anything otherwise. This means that in case of failed attestation, the result status remained as "none".

This commit sets status to contraindicated (and executables trust vector claim to unknown runtime) if reference value comparison fails.