### PR TITLE
set ownership of the build directory earlier

### DIFF
--- a/deployments/docker/src/builder-dispatcher
+++ b/deployments/docker/src/builder-dispatcher
@@ -29,10 +29,6 @@ function deploy() {
     mkdir -p $DEPLOY_DIR/logs
     mkdir -p $DEPLOY_DIR/utils
 
-    # tell git our build directory is "safe" -- the operating context of
-    # CVE-2022-24765 (i.e., multi-user machine) does not really apply here
-    git config --global --add safe.directory $BUILD_DIR
-
     echo "deploying services"
     cp $BUILD_DIR/provisioning/cmd/provisioning-service/provisioning-service $DEPLOY_DIR/
     cp $BUILD_DIR/verification/cmd/verification-service/verification-service $DEPLOY_DIR/

--- a/deployments/docker/src/builder.docker
+++ b/deployments/docker/src/builder.docker
@@ -46,8 +46,7 @@ RUN chown builder:builder /veraison
 
 USER builder
 
-RUN mkdir --mode=775 logs stores
-
+RUN mkdir --mode=775 logs stores build
 ADD --chown=builder:builder go.mod go.sum ./
 
 # Download Go modules


### PR DESCRIPTION
Create and set ownership of the build directory inside the Dockerfile

Fix #193 