### PR TITLE
verification: nonce size validation on session create

### DIFF
--- a/verification/api/handler.go
+++ b/verification/api/handler.go
@@ -136,8 +136,8 @@ func parseNonceRequest(nonceParam, nonceSizeParam string) ([]byte, error) {
 	// a nonceSize was supplied, try to use it to mint a new nonce
 	if nonceSizeParam != "" {
 		nonceSize, err := aToU8(nonceSizeParam)
-		if err != nil {
-			return nil, errors.New("nonceSize must be in range 1..256")
+		if err != nil || nonceSize < 8 || nonceSize > 64 {
+			return nil, errors.New("nonceSize must be in range 8..64")
 		}
 		return mintNonce(nonceSize)
 	}
@@ -146,6 +146,14 @@ func parseNonceRequest(nonceParam, nonceSizeParam string) ([]byte, error) {
 	nonce, err := b64ToBytes(nonceParam)
 	if err != nil {
 		return nil, errors.New("nonce must be valid base64")
+	}
+
+	nonceLen := len(nonce)
+	if nonceLen < 8 || nonceLen > 64 {
+		return nil, fmt.Errorf(
+			"nonce must be between 8 and 64 bytes long; got %d",
+			nonceLen,
+		)
 	}
 
 	return nonce, nil

--- a/verification/api/handler_test.go
+++ b/verification/api/handler_test.go
@@ -184,18 +184,18 @@ func TestHandler_NewChallengeResponse_AmbiguousQueryParameters(t *testing.T) {
 
 func TestHandler_NewChallengeResponse_NonceSizeTooBig(t *testing.T) {
 	q := url.Values{}
-	q.Add("nonceSize", "257")
+	q.Add("nonceSize", "88")
 
-	expectedErr := "failed handling nonce request: nonceSize must be in range 1..256"
+	expectedErr := "failed handling nonce request: nonceSize must be in range 8..64"
 
 	testHandler_NewChallengeResponse_BadNonce(t, q, expectedErr)
 }
 
-func TestHandler_NewChallengeResponse_NonceSizeIsZero(t *testing.T) {
+func TestHandler_NewChallengeResponse_NonceSizeTooSmall(t *testing.T) {
 	q := url.Values{}
-	q.Add("nonceSize", "0")
+	q.Add("nonceSize", "6")
 
-	expectedErr := "failed handling nonce request: nonce size cannot be 0"
+	expectedErr := "failed handling nonce request: nonceSize must be in range 8..64"
 
 	testHandler_NewChallengeResponse_BadNonce(t, q, expectedErr)
 }
@@ -269,11 +269,11 @@ func TestHandler_NewChallengeResponse_NonceParameter(t *testing.T) {
 	expectedType := ChallengeResponseSessionMediaType
 	expectedLocationRE := sessionURIRegexp
 	expectedSessionStatus := StatusWaiting
-	expectedNonce := []byte("nonce")
+	expectedNonce := []byte("nonce-value")
 
 	qParams := url.Values{}
-	// b64("nonce") => "bm9uY2U="
-	qParams.Add("nonce", "bm9uY2U=")
+	// b64("nonce-value") => "bm9uY2UtdmFsdWU="
+	qParams.Add("nonce", "bm9uY2UtdmFsdWU=")
 
 	w := httptest.NewRecorder()
 


### PR DESCRIPTION
Up to this point, on session creation, nonceSize parameter was required to be a non-zero uint8 (i.e. in range 1..255), and the nonce parameter was only verified to be  a valid base64 string, with no size limit.

The nonce eventually ends up inside EAR's eat_nonce claim, and therefore must comport with the restriction associated with that claim, which is between 8 and 64 bytes long. This will result in a failed attestation result generation in the subsequent submit request.

This commit modifies nonceSize limit check to be aligned with eat_nonce definition, and adds an analogous check for the nonce parameter. This will insure that attempting to define a nonce of an invalid size during session creation will result in a failure to create the session.