### PR TITLE
handler: add GetRefValueIDs to IStoreHandler 

### DIFF
--- a/handler/evidence_rpc.go
+++ b/handler/evidence_rpc.go
@@ -163,12 +163,15 @@ func (s *RPCClient) GetSupportedMediaTypes() []string {
 	return resp
 }
 
-func (s *RPCClient) ExtractEvidence(token *proto.AttestationToken, trustAnchors []string) (*ExtractedClaims, error) {
+func (s *RPCClient) ExtractEvidence(
+	token *proto.AttestationToken,
+	trustAnchors []string,
+) (map[string]interface{}, error) {
 	var (
 		err       error
 		args      ExtractClaimsArgs
 		resp      []byte
-		extracted ExtractedClaims
+		extracted map[string]interface{}
 	)
 
 	args.Token, err = json.Marshal(token)
@@ -188,7 +191,7 @@ func (s *RPCClient) ExtractEvidence(token *proto.AttestationToken, trustAnchors 
 		return nil, fmt.Errorf("unmarshaling extracted evidence: %w", err)
 	}
 
-	return &extracted, nil
+	return extracted, nil
 }
 
 func (s *RPCClient) ValidateEvidenceIntegrity(
@@ -240,11 +243,14 @@ func (s *RPCClient) AppraiseEvidence(ec *proto.EvidenceContext, endorsements []s
 	return &result, err
 }
 
-func (s *RPCClient) ExtractClaims(token *proto.AttestationToken, trustAnchors []string) (*ExtractedClaims, error) {
+func (s *RPCClient) ExtractClaims(
+	token *proto.AttestationToken,
+	trustAnchors []string,
+) (map[string]interface{}, error) {
 	var (
 		err             error
 		args            ExtractClaimsArgs
-		extractedClaims ExtractedClaims
+		extractedClaims map[string]interface{}
 	)
 
 	args.Token, err = json.Marshal(token)
@@ -266,5 +272,5 @@ func (s *RPCClient) ExtractClaims(token *proto.AttestationToken, trustAnchors []
 		return nil, fmt.Errorf("unmarshaling extracted claims: %w", err)
 	}
 
-	return &extractedClaims, nil
+	return extractedClaims, nil
 }

--- a/handler/ievidencehandler.go
+++ b/handler/ievidencehandler.go
@@ -19,7 +19,7 @@ type IEvidenceHandler interface {
 	ExtractClaims(
 		token *proto.AttestationToken,
 		trustAnchors []string,
-	) (*ExtractedClaims, error)
+	) (map[string]interface{}, error)
 
 	// ValidateEvidenceIntegrity verifies the structural integrity and validity of the
 	// token. The exact checks performed are scheme-specific, but they
@@ -49,22 +49,4 @@ type IEvidenceHandler interface {
 		ec *proto.EvidenceContext,
 		endorsements []string,
 	) (*ear.AttestationResult, error)
-}
-
-// ExtractedClaims contains a map of claims extracted from an attestation
-// token along with the corresponding ReferenceIDs that are used to fetch
-// the associated endorsements.
-//
-//	ReferenceID is the key used to fetch all the Endorsements
-//	generated from claims extracted from the token
-type ExtractedClaims struct {
-	ClaimsSet    map[string]interface{} `json:"claims-set"`
-	ReferenceIDs []string               `json:"reference-ids"`
-	// please refer issue #106 for unprocessed claim set
-}
-
-func NewExtractedClaims() *ExtractedClaims {
-	return &ExtractedClaims{
-		ClaimsSet: make(map[string]interface{}),
-	}
 }

--- a/handler/istorehandler.go
+++ b/handler/istorehandler.go
@@ -14,10 +14,19 @@ import (
 type IStoreHandler interface {
 	plugin.IPluggable
 
-	// GetTrustAnchorIDs returns an array of trust anchor identifiers used
+	// GetTrustAnchorIDs returns a slice of trust anchor identifiers used
 	// to retrieve the trust anchors associated with this token. The trust anchors may be necessary to validate the
 	// entire token and/or extract its claims (if it is encrypted).
 	GetTrustAnchorIDs(token *proto.AttestationToken) ([]string, error)
+
+	// GetRefValueIDs returns a slice of identifiers used to retrieve
+	// reference values for an attestation scheme, using the claims
+	// extracted from attestation token and the associated trust anchors.
+	GetRefValueIDs(
+		tenantID string,
+		trustAnchors []string,
+		claims map[string]interface{},
+	) ([]string, error)
 
 	// SynthKeysFromRefValue synthesizes lookup key(s) for the
 	// provided reference value endorsement.

--- a/scheme/cca-ssd-platform/evidence_handler.go
+++ b/scheme/cca-ssd-platform/evidence_handler.go
@@ -36,7 +36,7 @@ func (s EvidenceHandler) GetSupportedMediaTypes() []string {
 func (s EvidenceHandler) ExtractClaims(
 	token *proto.AttestationToken,
 	trustAnchors []string,
-) (*handler.ExtractedClaims, error) {
+) (map[string]interface{}, error) {
 
 	var ccaToken ccatoken.Evidence
 
@@ -44,7 +44,6 @@ func (s EvidenceHandler) ExtractClaims(
 		return nil, handler.BadEvidence(err)
 	}
 
-	var extracted handler.ExtractedClaims
 
 	platformClaimsSet, err := common.ClaimsToMap(ccaToken.PlatformClaims)
 	if err != nil {
@@ -58,18 +57,12 @@ func (s EvidenceHandler) ExtractClaims(
 			"could not convert realm claims: %w", err))
 	}
 
-	extracted.ClaimsSet = map[string]interface{}{
+	claims := map[string]interface{}{
 		"platform": platformClaimsSet,
 		"realm":    realmClaimsSet,
 	}
 
-	extracted.ReferenceIDs = []string{arm.RefValLookupKey(
-		SchemeName,
-		token.TenantId,
-		arm.MustImplIDString(ccaToken.PlatformClaims),
-	)}
-	log.Debugf("extracted Reference ID Key = %s", extracted.ReferenceIDs)
-	return &extracted, nil
+	return claims, nil
 }
 
 // ValidateEvidenceIntegrity, decodes CCA collection and then invokes Verify API of ccatoken library

--- a/scheme/cca-ssd-platform/evidence_handler_test.go
+++ b/scheme/cca-ssd-platform/evidence_handler_test.go
@@ -110,7 +110,7 @@ func Test_ExtractVerifiedClaims_ok(t *testing.T) {
 	ta := string(taEndValBytes)
 
 	extracted, err := scheme.ExtractClaims(&token, []string{ta})
-	platformClaims := extracted.ClaimsSet["platform"].(map[string]interface{})
+	platformClaims := extracted["platform"].(map[string]interface{})
 
 	require.NoError(t, err)
 	assert.Equal(t, "http://arm.com/CCA-SSD/1.0.0",

--- a/scheme/cca-ssd-platform/store_handler.go
+++ b/scheme/cca-ssd-platform/store_handler.go
@@ -4,8 +4,11 @@
 package cca_ssd_platform
 
 import (
+	"fmt"
+
 	"github.com/veraison/services/handler"
 	"github.com/veraison/services/proto"
+	"github.com/veraison/services/scheme/common"
 	"github.com/veraison/services/scheme/common/arm"
 )
 
@@ -42,4 +45,26 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 		return []string{""}, err
 	}
 	return []string{ta}, nil
+}
+
+func (s StoreHandler) GetRefValueIDs(
+	tenantID string,
+	trustAnchors []string,
+	claims map[string]interface{},
+) ([]string, error) {
+	platformClaimsMap, ok := claims["platform"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("claims to do not contain platform map: %v", claims)
+	}
+
+	platformClaims, err := common.MapToClaims(platformClaimsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{arm.RefValLookupKey(
+		SchemeName,
+		tenantID,
+		arm.MustImplIDString(platformClaims),
+	)}, nil
 }

--- a/scheme/parsec-cca/evidence_handler.go
+++ b/scheme/parsec-cca/evidence_handler.go
@@ -38,9 +38,11 @@ func (s EvidenceHandler) GetSupportedMediaTypes() []string {
 	return EvidenceMediaTypes
 }
 
-func (s EvidenceHandler) ExtractClaims(token *proto.AttestationToken, trustAnchors []string) (*handler.ExtractedClaims, error) {
+func (s EvidenceHandler) ExtractClaims(
+	token *proto.AttestationToken,
+	trustAnchors []string,
+) (map[string]interface{}, error) {
 	var (
-		extracted handler.ExtractedClaims
 		evidence  parsec_cca.Evidence
 		claimsSet = make(map[string]interface{})
 		kat       = make(map[string]interface{})
@@ -70,15 +72,7 @@ func (s EvidenceHandler) ExtractClaims(token *proto.AttestationToken, trustAncho
 	}
 	claimsSet["cca.realm"] = rmap
 
-	extracted.ClaimsSet = claimsSet
-
-	extracted.ReferenceIDs = []string{arm.RefValLookupKey(
-		SchemeName,
-		token.TenantId,
-		arm.MustImplIDString(evidence.Pat.PlatformClaims),
-	)}
-	log.Debugf("extracted Reference ID Key = %s", extracted.ReferenceIDs)
-	return &extracted, nil
+	return claimsSet, nil
 }
 
 func (s EvidenceHandler) ValidateEvidenceIntegrity(token *proto.AttestationToken, trustAnchors []string, endorsements []string) error {

--- a/scheme/parsec-cca/store_handler.go
+++ b/scheme/parsec-cca/store_handler.go
@@ -3,8 +3,11 @@
 package parsec_cca
 
 import (
+	"fmt"
+
 	"github.com/veraison/services/handler"
 	"github.com/veraison/services/proto"
+	"github.com/veraison/services/scheme/common"
 	"github.com/veraison/services/scheme/common/arm"
 )
 
@@ -41,4 +44,26 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 		return []string{""}, err
 	}
 	return []string{ta}, nil
+}
+
+func (s StoreHandler) GetRefValueIDs(
+	tenantID string,
+	trustAnchors []string,
+	claims map[string]interface{},
+) ([]string, error) {
+	platformClaimsMap, ok := claims["cca.platform"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("claims to do not contain patform map: %v", claims)
+	}
+
+	platformClaims, err := common.MapToClaims(platformClaimsMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{arm.RefValLookupKey(
+		SchemeName,
+		tenantID,
+		arm.MustImplIDString(platformClaims),
+	)}, nil
 }

--- a/scheme/parsec-tpm/common.go
+++ b/scheme/parsec-tpm/common.go
@@ -1,0 +1,9 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package parsec_tpm
+
+const (
+	ScopeTrustAnchor = "trust anchor"
+	ScopeRefValues   = "ref values"
+)
+

--- a/scheme/psa-iot/evidence_handler.go
+++ b/scheme/psa-iot/evidence_handler.go
@@ -34,28 +34,19 @@ func (s EvidenceHandler) GetSupportedMediaTypes() []string {
 func (s EvidenceHandler) ExtractClaims(
 	token *proto.AttestationToken,
 	trustAnchors []string,
-) (*handler.ExtractedClaims, error) {
+) (map[string]interface{}, error) {
 	var psaToken psatoken.Evidence
 
 	if err := psaToken.FromCOSE(token.Data); err != nil {
 		return nil, handler.BadEvidence(err)
 	}
 
-	var extracted handler.ExtractedClaims
-
 	claimsSet, err := common.ClaimsToMap(psaToken.Claims)
 	if err != nil {
 		return nil, handler.BadEvidence(err)
 	}
-	extracted.ClaimsSet = claimsSet
 
-	extracted.ReferenceIDs = []string{arm.RefValLookupKey(
-		SchemeName,
-		token.TenantId,
-		arm.MustImplIDString(psaToken.Claims),
-	)}
-	log.Printf("\n Extracted SW ID Key = %s", extracted.ReferenceIDs)
-	return &extracted, nil
+	return claimsSet, nil
 }
 
 func (s EvidenceHandler) ValidateEvidenceIntegrity(

--- a/scheme/psa-iot/evidence_handler_test.go
+++ b/scheme/psa-iot/evidence_handler_test.go
@@ -57,12 +57,12 @@ func Test_ExtractVerifiedClaims_ok(t *testing.T) {
 		Nonce:    testNonce,
 	}
 	ta := string(taEndValBytes)
-	extracted, err := handler.ExtractClaims(&token, []string{ta})
+	claims, err := handler.ExtractClaims(&token, []string{ta})
 
 	require.NoError(t, err)
-	assert.Equal(t, "PSA_IOT_PROFILE_1", extracted.ClaimsSet["psa-profile"].(string))
+	assert.Equal(t, "PSA_IOT_PROFILE_1", claims["psa-profile"].(string))
 
-	swComponents := extracted.ClaimsSet["psa-software-components"].([]interface{})
+	swComponents := claims["psa-software-components"].([]interface{})
 	assert.Len(t, swComponents, 4)
 	assert.Equal(t, "BL", swComponents[0].(map[string]interface{})["measurement-type"].(string))
 }

--- a/scheme/psa-iot/store_handler.go
+++ b/scheme/psa-iot/store_handler.go
@@ -6,6 +6,7 @@ package psa_iot
 import (
 	"github.com/veraison/services/handler"
 	"github.com/veraison/services/proto"
+	"github.com/veraison/services/scheme/common"
 	"github.com/veraison/services/scheme/common/arm"
 )
 
@@ -41,4 +42,21 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 	}
 
 	return []string{taID}, nil
+}
+
+func (s StoreHandler) GetRefValueIDs(
+	tenantID string,
+	trustAnchors []string,
+	claims map[string]interface{},
+) ([]string, error) {
+	psaClaims, err := common.MapToClaims(claims)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{arm.RefValLookupKey(
+		SchemeName,
+		tenantID,
+		arm.MustImplIDString(psaClaims),
+	)}, nil
 }

--- a/scheme/riot/evidence_handler.go
+++ b/scheme/riot/evidence_handler.go
@@ -36,7 +36,7 @@ func (s EvidenceHandler) GetSupportedMediaTypes() []string {
 func (s EvidenceHandler) ExtractClaims(
 	token *proto.AttestationToken,
 	trustAnchors []string,
-) (*handler.ExtractedClaims, error) {
+) (map[string]interface{}, error) {
 	roots := x509.NewCertPool()
 	intermediates := x509.NewCertPool()
 
@@ -67,12 +67,7 @@ func (s EvidenceHandler) ExtractClaims(
 			"failed to verify alias cert: " + err.Error())
 	}
 
-	extracted := handler.ExtractedClaims{
-		ClaimsSet:    claims,
-		ReferenceIDs: []string{"dice://"},
-	}
-
-	return &extracted, nil
+	return claims, nil
 }
 
 func (s EvidenceHandler) ValidateEvidenceIntegrity(

--- a/scheme/riot/evidence_handler_test.go
+++ b/scheme/riot/evidence_handler_test.go
@@ -42,8 +42,8 @@ func Test_ExtractVerifiedClaims_ok(t *testing.T) {
 		Data:     deviceData,
 	}
 	ta := string(taData)
-	evidence, err := s.ExtractClaims(&token, []string{ta})
+	claims, err := s.ExtractClaims(&token, []string{ta})
 	assert.Nil(t, err)
-	assert.Equal(t, FWID, evidence.ClaimsSet["FWID"])
-	assert.Equal(t, DeviceID, evidence.ClaimsSet["DeviceID"])
+	assert.Equal(t, FWID, claims["FWID"])
+	assert.Equal(t, DeviceID, claims["DeviceID"])
 }

--- a/scheme/riot/store_handler.go
+++ b/scheme/riot/store_handler.go
@@ -29,6 +29,14 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 	return []string{"dice://"}, nil
 }
 
+func (s StoreHandler) GetRefValueIDs(
+	tenantID string,
+	trustAnchors []string,
+	claims map[string]interface{},
+) ([]string, error) {
+	return []string{"dice://"}, nil
+}
+
 func (s StoreHandler) SynthKeysFromRefValue(tenantID string, swComp *handler.Endorsement) ([]string, error) {
 	return nil, errors.New("TODO")
 }

--- a/scheme/tpm-enacttrust/evidence_handler_test.go
+++ b/scheme/tpm-enacttrust/evidence_handler_test.go
@@ -61,12 +61,18 @@ func Test_ExtractVerifiedClaims_ok(t *testing.T) {
 		0x7a, 0xf, 0xde, 0x60, 0xc4, 0xcf, 0x25, 0xc7,
 	}
 
-	assert.Equal(t, 1, len(ev.ReferenceIDs))
-	assert.Equal(t, "TPM_ENACTTRUST://0/7df7714e-aa04-4638-bcbf-434b1dd720f1", ev.ReferenceIDs[0])
 	assert.Equal(t, []interface{}{int64(1), int64(2), int64(3), int64(4)},
-		ev.ClaimsSet["pcr-selection"])
-	assert.Equal(t, int64(11), ev.ClaimsSet["hash-algorithm"])
-	assert.Equal(t, expectedPCRDigest, ev.ClaimsSet["pcr-digest"])
+		ev["pcr-selection"])
+	assert.Equal(t, int64(11), ev["hash-algorithm"])
+	assert.Equal(t, expectedPCRDigest, ev["pcr-digest"])
+
+	var sh StoreHandler
+
+	refIDs, err := sh.GetRefValueIDs("0", []string{trustAnchor}, ev)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(refIDs))
+	assert.Equal(t, "TPM_ENACTTRUST://0/7df7714e-aa04-4638-bcbf-434b1dd720f1", refIDs[0])
 }
 
 func Test_ValidateEvidenceIntegrity_ok(t *testing.T) {


### PR DESCRIPTION
Move reference value ID extraction from evidence into store handler.
Prior to this, it was done inside evidence handler as part of claims
extraction.

This ensure that ID generation on both provisioning and verification
paths is handled in the same place, and is symmetrical with trust anchor
ID generation.

This also means that ExtractClaims method is now responsible _only_ for
claim extraction. ExtractedClaims structure is removed, and the method
now returns the map[string]interface{} claims set (ExtractedClaims
combined that with reference IDs).

This addresses: https://github.com/veraison/services/issues/214
