### PR TITLE
Makefile fixes

### DIFF
--- a/scheme/cca-ssd-platform/endorsement_handler_test.go
+++ b/scheme/cca-ssd-platform/endorsement_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Contributors to the Veraison project.
+// Copyright 2022-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package cca_ssd_platform
 

--- a/scheme/common/Makefile
+++ b/scheme/common/Makefile
@@ -3,12 +3,6 @@
 
 SUBDIR := arm
 
-all: all-hook-pre
-clean:
-
-all-hook-pre all-test-pre all-lint-pre:
-	$(MAKE) -C ../../handler
-
 include ../../mk/common.mk
 include ../../mk/lint.mk
 include ../../mk/test.mk

--- a/scheme/common/Makefile
+++ b/scheme/common/Makefile
@@ -1,5 +1,7 @@
-# Copyright 2022 Contributors to the Veraison project.
+# Copyright 2022-2024 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
+
+SUBDIR := arm
 
 all: all-hook-pre
 clean:
@@ -10,3 +12,4 @@ all-hook-pre all-test-pre all-lint-pre:
 include ../../mk/common.mk
 include ../../mk/lint.mk
 include ../../mk/test.mk
+include ../../mk/subdir.mk

--- a/scheme/common/arm/Makefile
+++ b/scheme/common/arm/Makefile
@@ -1,0 +1,7 @@
+# Copyright 2024 Contributors to the Veraison project.
+# SPDX-License-Identifier: Apache-2.0
+
+include ../../../mk/common.mk
+include ../../../mk/lint.mk
+include ../../../mk/pkg.mk
+include ../../../mk/test.mk

--- a/scheme/parsec-cca/endorsement_handler_test.go
+++ b/scheme/parsec-cca/endorsement_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Contributors to the Veraison project.
+// Copyright 2023-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package parsec_cca
 

--- a/scheme/parsec-tpm/endorsement_handler_test.go
+++ b/scheme/parsec-tpm/endorsement_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Contributors to the Veraison project.
+// Copyright 2023-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package parsec_tpm
 

--- a/scheme/psa-iot/endorsement_handler_test.go
+++ b/scheme/psa-iot/endorsement_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Contributors to the Veraison project.
+// Copyright 2022-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package psa_iot
 


### PR DESCRIPTION
- Make sure tests inside `scheme/common/arm` are run as part of `make test`
- Remove unnecessary  pre hook inside `scheme/common/Makefile` that caused problems by triggering copyright checks during Docker deployment creation.

This addresses https://github.com/veraison/services/issues/212