### PR TITLE
kvstore: add GetMultiple

### DIFF
--- a/kvstore/common.go
+++ b/kvstore/common.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Contributors to the Veraison project.
+// Copyright 2021-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package kvstore
 
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var ErrKeyNotFound = errors.New("key not found")
@@ -38,4 +39,30 @@ func sanitizeV(val string) error {
 	}
 
 	return nil
+}
+
+func getMultiple(store IKVStore, keys []string) ([]string, error) {
+	var vals []string
+	var notFound []string
+
+	for _, key := range keys {
+
+		keyVals, err := store.Get(key)
+		if err != nil {
+			if errors.Is(err, ErrKeyNotFound) {
+				notFound = append(notFound, fmt.Sprintf("%q", key))
+			} else {
+				return nil, err
+			}
+		}
+
+		vals = append(vals, keyVals...)
+	}
+
+	var err error = nil
+	if len(notFound) != 0 {
+		err = fmt.Errorf("%w: %s", ErrKeyNotFound, strings.Join(notFound, ", "))
+	}
+
+	return vals, err
 }

--- a/kvstore/ikvstore.go
+++ b/kvstore/ikvstore.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Contributors to the Veraison project.
+// Copyright 2021-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package kvstore
 
@@ -29,6 +29,16 @@ type IKVStore interface {
 	// values are in the order they were added, with the most recent value
 	// last.
 	Get(key string) ([]string, error)
+
+	// GetMultiple returns a []string of values for the specified keys. If
+	// any of the specified keys are not in the store, a ErrKeyNotFound
+	// is returned, listing all keys for which values could not be found
+	// (note that in this case, the returned slice will still contain
+	// values for other specified keys, if any). The order of the values
+	// matches the order of the keys; if there are multiple values for one
+	// key, they are in the order they were added, with the most recent
+	// value last.
+	GetMultiple(keys []string) ([]string, error)
 
 	// GetKeys returns a []string of keys currently set in the store.
 	GetKeys() ([]string, error)

--- a/kvstore/memory.go
+++ b/kvstore/memory.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Contributors to the Veraison project.
+// Copyright 2021-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package kvstore
 
@@ -61,6 +61,10 @@ func (o Memory) Get(key string) ([]string, error) {
 	}
 
 	return vals, nil
+}
+
+func (o Memory) GetMultiple(keys []string) ([]string, error) {
+	return getMultiple(&o, keys)
 }
 
 func (o Memory) GetKeys() ([]string, error) {

--- a/kvstore/memory_test.go
+++ b/kvstore/memory_test.go
@@ -65,6 +65,30 @@ func TestMemory_Set_Get_ok(t *testing.T) {
 	assert.Equal(t, testKey, keys[0])
 }
 
+func TestMemory_GetMultiple(t *testing.T) {
+	s := Memory{}
+
+	err := s.Init(nil, log.Named("test"))
+	require.NoError(t, err)
+
+	s.Data = map[string][]string{
+		"key1": []string{"1", "2"},
+		"key2": []string{"3", "4"},
+	}
+
+	ret, err := s.GetMultiple([]string{"key1", "key2"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1", "2", "3", "4"}, ret)
+
+	ret, err = s.GetMultiple([]string{"key2", "key1"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"3", "4", "1", "2"}, ret)
+
+	ret, err = s.GetMultiple([]string{"key1", "key2", "key3"})
+	assert.EqualError(t, err, `key not found: "key3"`)
+	assert.Equal(t, []string{"1", "2", "3", "4"}, ret)
+}
+
 func TestMemory_Get_empty_key(t *testing.T) {
 	s := Memory{}
 

--- a/kvstore/sql.go
+++ b/kvstore/sql.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Contributors to the Veraison project.
+// Copyright 2021-2024 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package kvstore
 
@@ -143,6 +143,10 @@ func (o SQL) Get(key string) ([]string, error) {
 	}
 
 	return vals, nil
+}
+
+func (o SQL) GetMultiple(keys []string) ([]string, error) {
+	return getMultiple(&o, keys)
 }
 
 func (o SQL) GetKeys() ([]string, error) {

--- a/vts/policymanager/mocks/ikvstore.go
+++ b/vts/policymanager/mocks/ikvstore.go
@@ -107,6 +107,21 @@ func (mr *MockIKVStoreMockRecorder) GetKeys() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeys", reflect.TypeOf((*MockIKVStore)(nil).GetKeys))
 }
 
+// GetMultiple mocks base method.
+func (m *MockIKVStore) GetMultiple(keys []string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultiple", keys)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMultiple indicates an expected call of GetMultiple.
+func (mr *MockIKVStoreMockRecorder) GetMultiple(keys interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultiple", reflect.TypeOf((*MockIKVStore)(nil).GetMultiple), keys)
+}
+
 // Init mocks base method.
 func (m *MockIKVStore) Init(v *viper.Viper, logger *zap.SugaredLogger) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Add GetMultiple method to IKVStore that allows fetching values for multiple keys from a store with a single call. This simplifies the usage of the store inside trusted services and can potentially improve performance for remote store implementations where call overhead may be non-trivial.

This addresses https://github.com/veraison/services/issues/207