### PR TITLE
Add github action to tag the repo monthly

### DIFF
--- a/.github/workflows/time-tag.yml
+++ b/.github/workflows/time-tag.yml
@@ -1,0 +1,18 @@
+name: Automatic monthly tag with format v0.0.yyMM
+on:
+  schedule:
+    # At 00:00 on the first day of each month
+    - cron: '0 0 1 * *'
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: action/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Generate a new tag and push it
+        run: |
+          TAG="v0.0.$(date +%y%m)"
+          git tag $TAG
+          git push origin $TAG


### PR DESCRIPTION
At midnight of every 1st day of the month, the repo is tagged with a "snapshot" tag.  The tag format is "v0.0.yyMM".