### PR TITLE
test(scheme): add missing GetRefValueIDs tests

### DIFF
--- a/scheme/cca-ssd-platform/store_handler_test.go
+++ b/scheme/cca-ssd-platform/store_handler_test.go
@@ -45,6 +45,27 @@ func Test_GetTrustAnchorIDs_ok(t *testing.T) {
 	assert.Equal(t, expectedTaID, taID)
 }
 
+func Test_GetRefValueIDs_ok(t *testing.T) {
+	rawToken, err := os.ReadFile("test/cca-token.json")
+	require.NoError(t, err)
+
+	tokenJSON := make(map[string]map[string]interface{})
+	err = json.Unmarshal(rawToken, &tokenJSON)
+	require.NoError(t, err)
+
+	platformClaims := tokenJSON["cca-platform-token"]
+	platformClaims["cca-platform-challenge"] = testNonce
+
+	claims := map[string]interface{}{"platform": platformClaims}
+
+	expectedRefvalIDs := []string{"CCA_SSD_PLATFORM://1/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}
+
+	scheme := &StoreHandler{}
+	refvalIDs, err := scheme.GetRefValueIDs("1", nil, claims)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRefvalIDs, refvalIDs)
+}
+
 func Test_SynthKeysFromTrustAnchor_ok(t *testing.T) {
 	endorsementsBytes, err := os.ReadFile("test/ta-endorsements.json")
 	require.NoError(t, err)

--- a/scheme/cca-ssd-platform/test/extracted.json
+++ b/scheme/cca-ssd-platform/test/extracted.json
@@ -52,7 +52,7 @@
 	    "cca-realm-public-key-hash-algo-id": "sha-512"
 	  }
   },
-  "reference-ids": ["CCA_SSD_PLATFORM://1/BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=/AQcGBQQDAgEADw4NDAsKCQgXFhUUExIREB8eHRwbGhkY"],
-  "trust-anchor-ids": ["CCA_SSD_PLATFORM://1/BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=/"],
+  "trust-anchor-ids": ["CCA_SSD_PLATFORM://1/BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=/AQcGBQQDAgEADw4NDAsKCQgXFhUUExIREB8eHRwbGhkY"],
+  "reference-ids": ["CCA_SSD_PLATFORM://1/BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=/"],
   "tenant-id": "1"
 }

--- a/scheme/parsec-cca/store_handler_test.go
+++ b/scheme/parsec-cca/store_handler_test.go
@@ -32,6 +32,24 @@ func Test_GetTrustAnchorIDs_ok(t *testing.T) {
 	assert.Equal(t, expectedTaID, taIDs[0])
 }
 
+func Test_GetRefValueIDs_ok(t *testing.T) {
+	rawToken, err := os.ReadFile("test/evidence/extracted.json")
+	require.NoError(t, err)
+
+	tokenJSON := make(map[string]interface{})
+	err = json.Unmarshal(rawToken, &tokenJSON)
+	require.NoError(t, err)
+
+	claims := tokenJSON["evidence"].(map[string]interface{})
+
+	expectedRefvalIDs := []string{"PARSEC_CCA://1/f0VMRgIBAQAAAAAAAAAAAAMAPgABAAAAUFgAAAAAAAA="}
+
+	scheme := &StoreHandler{}
+	refvalIDs, err := scheme.GetRefValueIDs("1", nil, claims)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRefvalIDs, refvalIDs)
+}
+
 func Test_SynthKeysFromTrustAnchor_ok(t *testing.T) {
 	endorsementsBytes, err := os.ReadFile("test/evidence/ta_endorsements.json")
 	require.NoError(t, err)

--- a/scheme/parsec-tpm/store_handler_test.go
+++ b/scheme/parsec-tpm/store_handler_test.go
@@ -32,6 +32,31 @@ func Test_GetTrustAnchorIDs_ok(t *testing.T) {
 	assert.Equal(t, []string{expectedTaID}, taIDs)
 }
 
+func Test_GetRefValueIDs_ok(t *testing.T) {
+	rawTA, err := os.ReadFile("test/evidence/ta_endorsements.json")
+	require.NoError(t, err)
+
+	trustAnchors := []string{string(rawTA)}
+
+	rawToken, err := os.ReadFile("test/evidence/extracted.json")
+	require.NoError(t, err)
+
+	tokenJSON := make(map[string]interface{})
+	err = json.Unmarshal(rawToken, &tokenJSON)
+	require.NoError(t, err)
+
+	claims := tokenJSON["evidence"].(map[string]interface{})
+
+	expectedRefvalID := "PARSEC_TPM://1/cd1f0e55-26f9-460d-b9d8-f7fde171787c"
+
+	handler := &StoreHandler{}
+
+	refvalIDs, err := handler.GetRefValueIDs("1", trustAnchors, claims)
+	require.NoError(t, err)
+	assert.Equal(t, []string{expectedRefvalID}, refvalIDs)
+}
+
+
 func Test_SynthKeysFromTrustAnchor_ok(t *testing.T) {
 	endorsementsBytes, err := os.ReadFile("test/evidence/ta_endorsements.json")
 	require.NoError(t, err)

--- a/scheme/psa-iot/store_handler_test.go
+++ b/scheme/psa-iot/store_handler_test.go
@@ -35,6 +35,23 @@ func Test_GetTrustAnchorIDs_ok(t *testing.T) {
 	assert.Equal(t, expectedTaID, taIDs[0])
 }
 
+func Test_GetRefValueIDs_ok(t *testing.T) {
+	rawToken, err := os.ReadFile("test/psa-token.json")
+	require.NoError(t, err)
+
+	claims := make(map[string]interface{})
+	err = json.Unmarshal(rawToken, &claims)
+	require.NoError(t, err)
+
+
+	expectedRefvalIDs := []string{"PSA_IOT://1/BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg="}
+
+	scheme := &StoreHandler{}
+	refvalIDs, err := scheme.GetRefValueIDs("1", nil, claims)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRefvalIDs, refvalIDs)
+}
+
 func Test_SynthKeysFromTrustAnchor_ok(t *testing.T) {
 	endorsementsBytes, err := os.ReadFile("test/ta-endorsements.json")
 	require.NoError(t, err)

--- a/scheme/psa-iot/test/psa-token.json
+++ b/scheme/psa-iot/test/psa-token.json
@@ -1,0 +1,36 @@
+{
+    "psa-boot-seed": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+    "psa-nonce": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+    "psa-client-id": 2,
+    "psa-implementation-id": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+    "psa-instance-id": "AQcGBQQDAgEADw4NDAsKCQgXFhUUExIREB8eHRwbGhkY",
+    "psa-profile": "PSA_IOT_PROFILE_1",
+    "psa-security-lifecycle": 3,
+    "psa-software-components": [
+        {
+            "measurement-description": "TF-M_SHA256MemPreXIP",
+            "measurement-value": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "signer-id": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "measurement-type": "BL",
+            "version": "3.4.2"
+        },
+        {
+            "measurement-value": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "signer-id": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "measurement-type": "M1",
+            "version": "1.2.0"
+        },
+        {
+            "measurement-value": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "signer-id": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "measurement-type": "M2",
+            "version": "1.2.3"
+        },
+        {
+            "measurement-value": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "signer-id": "BwYFBAMCAQAPDg0MCwoJCBcWFRQTEhEQHx4dHBsaGRg=",
+            "measurement-type": "M3",
+            "version": "1.0.0"
+        }
+    ]
+}

--- a/scheme/tpm-enacttrust/store_handler_test.go
+++ b/scheme/tpm-enacttrust/store_handler_test.go
@@ -3,6 +3,7 @@
 package tpm_enacttrust
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/veraison/services/proto"
 )
 
-func Test_GetTrustAnchorIds_ok(t *testing.T) {
+func Test_GetTrustAnchorIDs_ok(t *testing.T) {
 	data, err := os.ReadFile("test/tokens/basic.token")
 	require.NoError(t, err)
 
@@ -26,4 +27,21 @@ func Test_GetTrustAnchorIds_ok(t *testing.T) {
 	taIDs, err := s.GetTrustAnchorIDs(&ta)
 	require.NoError(t, err)
 	assert.Equal(t, "TPM_ENACTTRUST://0/7df7714e-aa04-4638-bcbf-434b1dd720f1", taIDs[0])
+}
+
+func Test_GetRefValueIDs_ok(t *testing.T) {
+	raw, err := os.ReadFile("test/tokens/basic.json")
+	require.NoError(t, err)
+
+	claims := make(map[string]interface{})
+	err = json.Unmarshal(raw, &claims)
+	require.NoError(t, err)
+
+	expectedRefvalIDs := []string{"TPM_ENACTTRUST://0/7df7714e-aa04-4638-bcbf-434b1dd720f1"}
+
+	s := StoreHandler{}
+
+	refvalIDs, err := s.GetRefValueIDs("0", nil, claims)
+	require.NoError(t, err)
+	assert.Equal(t, expectedRefvalIDs, refvalIDs)
 }


### PR DESCRIPTION
When GetRefValueIDs was moved to StoreHandler, it was no longer tested as part of the existing ExtractClaims tests. Add StoreHandler tests to rectify this.