### PR TITLE
fix: correctly report VTS down in API server logs

### DIFF
--- a/provisioning/cmd/provisioning-service/main.go
+++ b/provisioning/cmd/provisioning-service/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/veraison/services/auth"
 	"github.com/veraison/services/config"
 	"github.com/veraison/services/log"
+	"github.com/veraison/services/proto"
 	"github.com/veraison/services/provisioning/api"
 	"github.com/veraison/services/provisioning/provisioner"
 	"github.com/veraison/services/vtsclient"
@@ -79,7 +80,13 @@ func main() {
 
 	vtsState, err := vtsClient.GetServiceState(context.TODO(), &emptypb.Empty{})
 	if err == nil {
-		log.Infow("vts connection established", "server-version", vtsState.ServerVersion)
+		if vtsState.Status == proto.ServiceStatus_SERVICE_STATUS_READY {
+			log.Infow("vts connection established", "server-version",
+				vtsState.ServerVersion)
+		} else {
+			log.Warnw("VTS server not ready. If you do not expect the server to be running yet, this is probably OK, otherwise it may indicate an issue with your vts.server-addr in your settings",
+				"server-state", vtsState.Status.String())
+		}
 	} else {
 		log.Warnw("Could not connect to VTS server. If you do not expect the server to be running yet, this is probably OK, otherwise it may indicate an issue with your vts.server-addr in your settings",
 			"error", err)

--- a/verification/cmd/verification-service/main.go
+++ b/verification/cmd/verification-service/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/veraison/services/config"
 	"github.com/veraison/services/log"
+	"github.com/veraison/services/proto"
 	"github.com/veraison/services/verification/api"
 	"github.com/veraison/services/verification/sessionmanager"
 	"github.com/veraison/services/verification/verifier"
@@ -65,7 +66,13 @@ func main() {
 
 	vtsState, err := vtsClient.GetServiceState(context.TODO(), &emptypb.Empty{})
 	if err == nil {
-		log.Infow("vts connection established", "server-version", vtsState.ServerVersion)
+		if vtsState.Status == proto.ServiceStatus_SERVICE_STATUS_READY {
+			log.Infow("vts connection established", "server-version",
+				vtsState.ServerVersion)
+		} else {
+			log.Warnw("VTS server not ready. If you do not expect the server to be running yet, this is probably OK, otherwise it may indicate an issue with your vts.server-addr in your settings",
+				"server-state", vtsState.Status.String())
+		}
 	} else {
 		log.Warnw("Could not connect to VTS server. If you do not expect the server to be running yet, this is probably OK, otherwise it may indicate an issue with vts.server-addr in your settings",
 			"error", err)


### PR DESCRIPTION
API frontends may be started before VTS. On start up, the frontend attempts to connect to the service and if the service is not ready, it is supposed to output a warning.

This was established by checking for error from
vtsClient.GetServiceState(). However, this will not always error. If a connection cannot be established this may return no error, but report the service as down.

In addition to checking for error, check that the service state is "READY", and warn if its not.