### PR TITLE
fix(builtin): update schemes.gen.go

### DIFF
--- a/builtin/schemes.gen.go
+++ b/builtin/schemes.gen.go
@@ -1,24 +1,33 @@
 package builtin
 
 import (
-	"github.com/veraison/services/plugin"
+        "github.com/veraison/services/plugin"
 
-	scheme1 "github.com/veraison/services/scheme/arm-cca"
-	scheme4 "github.com/veraison/services/scheme/psa-iot"
-	scheme2 "github.com/veraison/services/scheme/riot"
-	scheme3 "github.com/veraison/services/scheme/tpm-enacttrust"
+        scheme1 "github.com/veraison/services/scheme/parsec-cca"
+        scheme2 "github.com/veraison/services/scheme/riot"
+        scheme3 "github.com/veraison/services/scheme/arm-cca"
+        scheme4 "github.com/veraison/services/scheme/tpm-enacttrust"
+        scheme5 "github.com/veraison/services/scheme/parsec-tpm"
+        scheme6 "github.com/veraison/services/scheme/psa-iot"
+
 )
 
 var plugins = []plugin.IPluggable{
-	&scheme1.EvidenceHandler{},
-	&scheme1.EndorsementHandler{},
-	&scheme1.StoreHandler{},
-	&scheme2.EvidenceHandler{},
-	&scheme2.StoreHandler{},
-	&scheme3.EvidenceHandler{},
-	&scheme3.EndorsementHandler{},
-	&scheme3.StoreHandler{},
-	&scheme4.EvidenceHandler{},
-	&scheme4.EndorsementHandler{},
-	&scheme4.StoreHandler{},
+        &scheme1.EvidenceHandler{},
+        &scheme1.EndorsementHandler{},
+        &scheme1.StoreHandler{},
+        &scheme2.EvidenceHandler{},
+        &scheme2.StoreHandler{},
+        &scheme3.EvidenceHandler{},
+        &scheme3.EndorsementHandler{},
+        &scheme3.StoreHandler{},
+        &scheme4.EvidenceHandler{},
+        &scheme4.EndorsementHandler{},
+        &scheme4.StoreHandler{},
+        &scheme5.EvidenceHandler{},
+        &scheme5.EndorsementHandler{},
+        &scheme5.StoreHandler{},
+        &scheme6.EvidenceHandler{},
+        &scheme6.EndorsementHandler{},
+        &scheme6.StoreHandler{},
 }

--- a/scheme/README.md
+++ b/scheme/README.md
@@ -12,6 +12,12 @@ schemes. Currently the following schemes are implemented:
 - `parsec-cca` : Parsec CCA based hardware-backed attestation, details
    [here](https://github.com/CCC-Attestation/attested-tls-poc/blob/main/doc/parsec-evidence-cca.md)
 
+> [!NOTE]
+> When adding (or removing) a scheme, please update `../builtin/scheme.gen.go`
+> to include the appropriate entries. This can be done automatically using
+> `../scripts/gen-schemes` script (see `../buildin/Makefile`) or by manually
+> editing the file. The script takes a long time to execute, so unless multiple
+> schemes are being added/moved/deleted, manual editing may be easier.
 
 ## Implementing Attestation Scheme Support
 


### PR DESCRIPTION
Update schemes.gen.go to include recent schemes (parsec-cca and parsec-tpm) and StoreHandler instances.

Due to git faffing with mtime's, make cannot always detect when the file needs to be re-generated automatically.