### PR TITLE
fix(docker): pin dlv version to v1.22.1

### DIFF
--- a/deployments/docker/src/builder.docker
+++ b/deployments/docker/src/builder.docker
@@ -63,7 +63,7 @@ RUN go mod download &&\
     go install github.com/veraison/corim/cocli@latest &&\
     go install github.com/veraison/evcli/v2@latest &&\
     go install github.com/veraison/pocli@latest &&\
-    go install github.com/go-delve/delve/cmd/dlv@latest
+    go install github.com/go-delve/delve/cmd/dlv@v1.22.1
 
 ADD --chown=builder:builder builder-dispatcher .
 ADD --chown=builder:builder builder-bashrc /home/builder/.bashrc


### PR DESCRIPTION
dlv@v1.23.0 is incompatible with golang 1.19 which is used by the docker builder.

This change pins dlv version to @v1.22.1 in the builder's Dockerfile to avoid breaking the 'docker-deployment' target.

Fix #247 