### PR TITLE
fix(docker): fix case mismatch warnings

### DIFF
--- a/deployments/docker/src/builder.docker
+++ b/deployments/docker/src/builder.docker
@@ -2,7 +2,7 @@
 # within the project, it must be at least 1.19.
 ARG GO_VERSION=1.19
 
-FROM golang:${GO_VERSION} as veraison-builder
+FROM golang:${GO_VERSION} AS veraison-builder
 
 # User identity that will be used to build the project. This should be
 # overriden at build time to match the host user running the builder, who owns

--- a/deployments/docker/src/keycloak.docker
+++ b/deployments/docker/src/keycloak.docker
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:22.0.1 as keycloak-builder
+FROM quay.io/keycloak/keycloak:22.0.1 AS keycloak-builder
 
 WORKDIR /opt/keycloak
 # note: for development set up early; use proper certification in production.

--- a/deployments/docker/src/management.docker
+++ b/deployments/docker/src/management.docker
@@ -1,7 +1,7 @@
 # Management service container.
 # The context for building this image is assumed to be the Veraison deployment
 # directory (/tmp/veraison is the default for make build).
-FROM debian as veraison-management
+FROM debian AS veraison-management
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/deployments/docker/src/manager.docker
+++ b/deployments/docker/src/manager.docker
@@ -1,7 +1,7 @@
 # VTS service container.
 # The context for building this image is assumed to be the Veraison deployment
 # directory (/tmp/veraison is the default for make build).
-FROM debian as veraison-verification
+FROM debian AS veraison-verification
 
 # User identity that will be used to build the project. This should be
 # overriden at build time to match the host user running the builder, who owns

--- a/deployments/docker/src/provisioning.docker
+++ b/deployments/docker/src/provisioning.docker
@@ -1,7 +1,7 @@
 # Provisioning service container.
 # The context for building this image is assumed to be the Veraison deployment
 # directory (/tmp/veraison is the default for make build).
-FROM debian as veraison-provisioning
+FROM debian AS veraison-provisioning
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/deployments/docker/src/verification.docker
+++ b/deployments/docker/src/verification.docker
@@ -1,7 +1,7 @@
 # Verification service container.
 # The context for building this image is assumed to be the Veraison deployment
 # directory (/tmp/veraison is the default for make build).
-FROM debian as veraison-verification
+FROM debian AS veraison-verification
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/deployments/docker/src/vts.docker
+++ b/deployments/docker/src/vts.docker
@@ -1,7 +1,7 @@
 # VTS service container.
 # The context for building this image is assumed to be the Veraison deployment
 # directory (/tmp/veraison is the default for make build).
-FROM debian as veraison-vts
+FROM debian AS veraison-vts
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -1,6 +1,6 @@
-# Copyright 2023 Contributors to the Veraison project.
+# Copyright 2023-2024 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
-FROM python as veraison-test
+FROM python AS veraison-test
 
 # User identify that will be used to build the project. This should be
 # overriden at build time to match the host user running the tester who owns


### PR DESCRIPTION
Latest docker started reporting warnings that the "FROM" and "as" cases don't match.