### PR TITLE
chore: enable combined plugins by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-# Copyright 2021 Contributors to the Veraison project.
+# Copyright 2021-2024 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
 
 export TOPDIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+# There will be one plugin built for each scheme. Removing this definition will
+# cause a separate plugin to be built for each handler interface (endorsement,
+# store, and verification), resulting in three plugins per scheme.
+export COMBINED_PLUGINS = 1
 
 SHELL = /bin/bash
 


### PR DESCRIPTION
Enable the building of a single, combined plugin per scheme.

Having separate plugins for different handler interfaces originally made some sense, as they were being loaded by different services (and could therefore be potentially deployed to different systems).

Since 20277644, all interfaces are loaded by the VTS, so having separate plugins for them no longer makes any sense.

Other reasons to combine plugins:

- It shortens build time quite significantly. On my system, by about eight seconds:
```
	$ for i in $(seq 1 3); do
		make clean &>/dev/null && \ 
                { time make &>/dev/null; } 2>&1 \ 
                | grep real | cut -f2;
         done 
         0m19.769s
         0m19.611s
         0m19.635s
```
  and with combined plugins:

```
	0m11.876s
	0m11.854s
	0m11.883s
```
- It results in less space being consumed on disk. The vast majority of the size of an executable is due to Go runtime.

```
	$ stat -c "%s %n" scheme/bin/* | numfmt --to iec
	22M scheme/bin/arm-cca-endorsement-handler.plugin
	22M scheme/bin/arm-cca-evidence-handler.plugin
	21M scheme/bin/arm-cca-store-handler.plugin
	22M scheme/bin/parsec-cca-endorsement-handler.plugin
	22M scheme/bin/parsec-cca-evidence-handler.plugin
	21M scheme/bin/parsec-cca-store-handler.plugin
	22M scheme/bin/parsec-tpm-endorsement-handler.plugin
	22M scheme/bin/parsec-tpm-evidence-handler.plugin
	21M scheme/bin/parsec-tpm-store-handler.plugin
	22M scheme/bin/psa-endorsement-handler.plugin
	22M scheme/bin/psa-evidence-handler.plugin
	21M scheme/bin/psa-store-handler.plugin
	20M scheme/bin/riot.plugin
	21M scheme/bin/tcg-dice-evidence-handler.plugin
	22M scheme/bin/tpm-enacttrust-endorsement-handler.plugin
	22M scheme/bin/tpm-enacttrust-evidence-handler.plugin
	21M scheme/bin/tpm-enacttrust-store-handler.plugin
```

  and with combined plugins:

```
	$ stat -c "%s %n" scheme/bin/* | numfmt --to iec
	23M scheme/bin/arm-cca.plugin
	23M scheme/bin/parsec-cca.plugin
	23M scheme/bin/parsec-tpm.plugin
	23M scheme/bin/psa.plugin
	21M scheme/bin/riot.plugin
	23M scheme/bin/tpm-enacttrust.plugin
```

  actual scheme code only take up ~1-3M of the binary, with ~20M being Go runtime.

- Both "docker" and "native" deployments already use combined plugins (for the reasons above). If someone creates a deployment, and then re-builds everything by doing "make", right now that would result in both combined and split plugin executables being inside scheme/bin/. If they then run vts pointing it at that directory (or copy it into a deployment), that will result in an error as the same implementation will be advertised by multiple plugins.