### PR TITLE
build: enable cgo

### DIFF
--- a/mk/cmd.mk
+++ b/mk/cmd.mk
@@ -36,7 +36,7 @@ _check_scheme_loader:
 	fi
 
 $(CMD): $(SRCS) $(CMD_DEPS) _check_scheme_loader _check_version
-	go build -o $(CMD) -ldflags \
+	CGO_ENABLED=1 go build -o $(CMD) -ldflags \
 	"-X 'github.com/veraison/services/config.Version=$(VERSION_FROM_GIT)' \
 	 -X 'github.com/veraison/services/config.SchemeLoader=$(SCHEME_LOADER)'"
 

--- a/mk/plugin.mk
+++ b/mk/plugin.mk
@@ -22,7 +22,7 @@ else
   DFLAGS :=
 endif
 
-$(PLUGIN): $(SRCS) ; go build $(DFLAGS) -o $(PLUGIN)
+$(PLUGIN): $(SRCS) ; CGO_ENABLED=1 go build $(DFLAGS) -o $(PLUGIN)
 
 .PHONY: all
 all: all-hook-pre realall


### PR DESCRIPTION
cgo allows the use of C libraries in GoLang. Some packages like sqlite3 depend on this feature.

We could allow this, barring any security issues (e.g., we can't confirm the hash of a C library before linking it).