### PR TITLE
fix(docker): fully propagate deployment settings

### DIFF
--- a/deployments/docker/Makefile
+++ b/deployments/docker/Makefile
@@ -18,6 +18,7 @@ DOCKER_BUILD_FLAGS ?=
 SHELL = /bin/bash
 
 THIS_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+include deployment.cfg
 include src/load-config.mk
 
 SRC_DIR := $(THIS_DIR)src/


### PR DESCRIPTION
Fully propagate deployment settings to the build environment.

Fix #295 