### PR TITLE
fix(github): fix "on" spec for time-package

### DIFF
--- a/.github/workflows/time-package.yml
+++ b/.github/workflows/time-package.yml
@@ -1,7 +1,7 @@
 name: Automatic package creation based on the monthly tag
 on:
-  - workflow_dispatch
-  - push:
+  workflow_dispatch:
+  push:
       tags:
         - v0.0.**
 permissions:


### PR DESCRIPTION
When one (or more) of the events have configuration, they cannot be specified as a list, and must instead be specified as a map with even names as keys.