### PR TITLE
doc(README): add note on pre-built packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository contains attestation services assembled using Veraison components.
 
+## Pre-built packages
+
+Packages are automatically generated for each monthly tag, you can find them
+attached to the [corresponding job
+here](https://github.com/veraison/services/actions/workflows/time-package.yml).
+
 ## Getting Started
 
 This section contains the instructions for creating a test deployment of


### PR DESCRIPTION
Add a note linking to the monthly jobs that automatically build packages associated with monthly tags.