### PR TITLE
feat(aws): option to use existing deb during make deploy

### DIFF
--- a/deployments/aws/README.md
+++ b/deployments/aws/README.md
@@ -109,6 +109,15 @@ make deploy
 > This could take a while -- in the order of 45 minutes, depending on how
 > responsive AWS is.
 
+> [!NOTE]
+> It's possible to use an existing Veraison Debian package when creating the
+> deployment (by default, one will be built from source as part of the
+> process).
+> To do so, set `VERAISON_DEB` environment variable to point to the package
+> before calling `make deploy`. (You can also add the variable to the config
+> file you are using with  `AWS_ACCOUNT_CFG`).
+>
+
 Deployment can be accessed via CLI front end:
 
 ```bash
@@ -185,7 +194,12 @@ The bring up stages are:
 
 ```bash
 veraison configure --init [...]
+
 veraison create-deb
+# or
+# veraison add-deb "$VERAISON_DEB"
+# if VERAISON_DEB is set
+
 veraison create-key-pair
 
 veraison create-vpc-stack

--- a/deployments/aws/deployment.cfg
+++ b/deployments/aws/deployment.cfg
@@ -107,3 +107,13 @@ MAX_DBMS_CONNECTIONS=${MAX_DBMS_CONNECTIONS:-75}
 # transfer it to Route53 first, please see
 #    https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-transfer-to-route-53.html
 #VERAISON_AWS_DNS_NAME=
+
+# A Debian package containing Veraison will be built as part of creating the
+# deployment and used to create the EC2 images running Veraison services.
+# Alternatively, VERAISON_DEB can be set to point to an existing package, in
+# which case, that will be used instead. This is useful to avoid having to deal
+# with cross-compilation issues on non-Linux or non-x86_64 platforms. Pre-built
+# Debian packages can be found attached as artifacts to these GitHub
+# jobs:
+#    https://github.com/veraison/services/actions/workflows/time-package.yml
+#VERAISON_DEB=

--- a/deployments/aws/deployment.sh
+++ b/deployments/aws/deployment.sh
@@ -142,7 +142,12 @@ function bringup() {
 		--iam-permission-boundary-arn "${IAM_PERMISSION_BOUNDARY_ARN}" \
 		--max-dbms-connections "${MAX_DBMS_CONNECTIONS}"
 
-	veraison create-deb
+	if [[ "${VERAISON_DEB}" == "" ]]; then
+		veraison create-deb
+	else
+		veraison add-deb "${VERAISON_DEB}"
+	fi
+
 	veraison create-key-pair
 
 	veraison create-vpc-stack


### PR DESCRIPTION
Make it more straight-forward to using an existing Debian package when creating the AWS deployment.

If VERAISON_DEB environment variable is specified, use the deb file it points to (using the previously-added "veraison add-deb") during "make deploy" instead of calling "veraison created-deb".