### PR TITLE
fix(github): turn off cache for actions/setup-go@v4

### DIFF
--- a/.github/workflows/time-package.yml
+++ b/.github/workflows/time-package.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "1.22"
+          cache: false
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Caching started being enabled by default in v4. With it enabled, we get "Restore cache failed" warnings.

To avoid this and return to pre-v4 behavior, explicitly disable cache.