### PR TITLE
fix(aws): fix Ubuntu ID case in bootstrap

### DIFF
--- a/deployments/aws/deployment.sh
+++ b/deployments/aws/deployment.sh
@@ -68,7 +68,7 @@ function bootstrap() {
 
 			case $distrib_id in
 			arch) sudo pacman -Syy packer ssh;;
-			Ubuntu)
+			ubuntu)
 				sudo apt update
 				sudo apt --yes install curl postgresql
 


### PR DESCRIPTION
Commit 87e4f625 changed to using /etc/os-release for getting the distribution ID. The ID in that is lower case, so the subsequent case statement needs to be updated.