### PR TITLE
fix(aws): replace hard-coded permission boundary

### DIFF
--- a/deployments/aws/bin/veraison
+++ b/deployments/aws/bin/veraison
@@ -904,7 +904,6 @@ class CreateSupportStackCommand(BaseCommand):
         # warry about correctrly escaping everything at every stage. Using a longer string
         # to compensate.
         password = randomword(40)
-        self.cache['postgres_admin_password'] = password
 
         extra_params = [
             {'ParameterKey': 'VpcId', 'ParameterValue': vpc_id},
@@ -923,6 +922,8 @@ class CreateSupportStackCommand(BaseCommand):
 
         command_create_stack(cmd, args.deployment_name, 'support',
                              template_path, extra_params, args.wait_period)
+
+        self.cache['postgres_admin_password'] = password
 
 
 class CreateServicesStackCommand(BaseCommand):

--- a/deployments/aws/deployment.sh
+++ b/deployments/aws/deployment.sh
@@ -168,7 +168,7 @@ function bringup() {
 function teardown() {
 	set +e
 	veraison delete-stack services
-	veraison delete-stack rds
+	veraison delete-stack support
 	veraison delete-stack vpc
 
 	veraison delete-image keycloak

--- a/deployments/aws/templates/stack-services.yaml
+++ b/deployments/aws/templates/stack-services.yaml
@@ -673,7 +673,7 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Path: /
-      PermissionsBoundary: arn:aws:iam::775539126253:policy/ProjAdminsPermBoundaryv2
+      PermissionsBoundary: !Ref PermissionBoundaryArn
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:


### PR DESCRIPTION
Replace the hard-coded permission boundary ARN with the parameter that was supposed to be used.