### PR TITLE
Fixes for the RPM deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ Available targets:
 	               and MacOSX using homebrew)
 	native-deploy: create and start the native deployment
 	deb:           create .deb package for installation on Debian or Ubuntu
+	rpm:           create .rpm package for installation on Fedora-like distros
 endef
 export __MAKEFILE_HELP
 
@@ -112,6 +113,7 @@ endif
 really-clean:
 	make -C integration-tests really-clean
 	make -C deployments/debian really-clean
+	make -C deployments/rpm really-clean
 	make -C deployments/docker really-clean
 	make -C deployments/native really-clean
 
@@ -174,7 +176,15 @@ endif
 deb:
 	make -C deployments/debian deb
 
+.PHONY: rpm
+rpm:
+	make -C deployments/rpm rpm
+
 ifeq ($(filter deb,$(MAKECMDGOALS)),deb)
+__NO_RECURSE = true
+endif
+
+ifeq ($(filter rpm,$(MAKECMDGOALS)),rpm)
 __NO_RECURSE = true
 endif
 

--- a/deployments/rpm/deployment.sh
+++ b/deployments/rpm/deployment.sh
@@ -5,7 +5,6 @@ _error='\e[0;31mERROR\e[0m'
 _this_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 _repo_root=$(realpath "${_this_dir}/../..")
-_version=$("${_repo_root}/scripts/get-veraison-version")
 
 
 function bootstrap() {
@@ -16,13 +15,18 @@ function bootstrap() {
 function create_rpm() {
 	_check_installed rpmbuild
 
-	local work_dir=${1:-/tmp}
-	local arch; arch="$(arch)"
-	local pkg_dir=${work_dir}/veraison_${_version}_${arch}
-
 	set -a
 	source "${_this_dir}/deployment.cfg"
 	set +a
+
+	if [[ -v VERAISON_BUILD_VERSION ]]; then
+		export VERAISON_BUILD_VERSION=${VERAISON_BUILD_VERSION}
+	fi
+
+	local version=$("${_repo_root}/scripts/get-veraison-version")
+	local work_dir=${1:-/tmp}
+	local arch; arch="$(arch)"
+	local pkg_dir=${work_dir}/veraison_${version}_${arch}
 
 	export VERAISON_ROOT=${VERAISON_ROOT}
 	export DEPLOYMENT_DEST=${pkg_dir}${VERAISON_ROOT}
@@ -31,7 +35,7 @@ function create_rpm() {
 	export VERIFICATION_HOST=$VERAISON_HOST
 	export MANAGEMENT_HOST=$VERAISON_HOST
 
-	export _VERAISON_VERSION=${_version}
+	export _VERAISON_VERSION=${version}
 
 	export GOOS=linux
 

--- a/deployments/rpm/veraison.spec.template
+++ b/deployments/rpm/veraison.spec.template
@@ -52,6 +52,7 @@ fi
 getent group %{GROUPNAME} >/dev/null 2>&1 && usermod -a -G %{GROUPNAME} %{USERNAME} || true
 
 %post
+/%{_prefix}/local/veraison/bin/veraison -f gen-service-certs localhost,@@-service,$(hostname -f)
 chown -R %{USERNAME}:%{GROUPNAME} /%{_prefix}/local/veraison/
 chmod 500 /%{_prefix}/local/veraison/certs/*.key
 /%{_prefix}/local/veraison/bin/veraison -s start-services

--- a/deployments/rpm/veraison.spec.template
+++ b/deployments/rpm/veraison.spec.template
@@ -7,6 +7,7 @@ License:        APACHE
 Source0:        %{name}-%{version}.tar.gz
 
 Requires:       /usr/bin/bash
+Requires:       sqlite > 3
 
 %global USERNAME _VERAISON_USER_
 %global GROUPNAME _VERAISON_GROUP_


### PR DESCRIPTION
Add some fixes for the RPM deployment:
- Adds top-level Makefile target for RPM
- Updates the post install script to generate certificates with server's hostname
- Configure build version
- Add dependency on sqlite3 package