### PR TITLE
  Fix CI ARM64 compatibility by replacing arduino/setup-protoc@v1 with cross-platform protoc installation #60

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -39,10 +39,27 @@ jobs:
       run: |
         go install golang.org/x/tools/cmd/guru@latest
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Install protoc with ARM64 support
+        PROTOC_VERSION="25.1"
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "x86_64" ]]; then
+          PROTOC_ARCH="x86_64"
+        elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+          PROTOC_ARCH="aarch_64"
+        else
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+        fi
+        
+        PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
+        curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
+        sudo unzip -o "$PROTOC_ZIP" -d /usr/local bin/protoc
+        sudo unzip -o "$PROTOC_ZIP" -d /usr/local 'include/*'
+        rm -f "$PROTOC_ZIP"
+        
+        # Verify installation
+        protoc --version
     - name: protoc-gen deps
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,27 @@ jobs:
       run: |
         go install golang.org/x/tools/cmd/guru@latest
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Install protoc with ARM64 support
+        PROTOC_VERSION="25.1"
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "x86_64" ]]; then
+          PROTOC_ARCH="x86_64"
+        elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+          PROTOC_ARCH="aarch_64"
+        else
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+        fi
+        
+        PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
+        curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
+        sudo unzip -o "$PROTOC_ZIP" -d /usr/local bin/protoc
+        sudo unzip -o "$PROTOC_ZIP" -d /usr/local 'include/*'
+        rm -f "$PROTOC_ZIP"
+        
+        # Verify installation
+        protoc --version
     - name: protoc-gen deps
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,10 +26,27 @@ jobs:
       run: |
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Install protoc with ARM64 support
+        PROTOC_VERSION="25.1"
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "x86_64" ]]; then
+          PROTOC_ARCH="x86_64"
+        elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+          PROTOC_ARCH="aarch_64"
+        else
+          echo "Unsupported architecture: $ARCH"
+          exit 1
+        fi
+        
+        PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
+        curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
+        sudo unzip -o "$PROTOC_ZIP" -d /usr/local bin/protoc
+        sudo unzip -o "$PROTOC_ZIP" -d /usr/local 'include/*'
+        rm -f "$PROTOC_ZIP"
+        
+        # Verify installation
+        protoc --version
     - name: protoc-gen deps
       run: |
         go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26

--- a/.github/workflows/time-package.yml
+++ b/.github/workflows/time-package.yml
@@ -35,10 +35,27 @@ jobs:
         run: |
           go install golang.org/x/tools/cmd/guru@latest
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: '3.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Install protoc with ARM64 support
+          PROTOC_VERSION="25.1"
+          ARCH=$(uname -m)
+          if [[ "$ARCH" == "x86_64" ]]; then
+            PROTOC_ARCH="x86_64"
+          elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+            PROTOC_ARCH="aarch_64"
+          else
+            echo "Unsupported architecture: $ARCH"
+            exit 1
+          fi
+          
+          PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
+          curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
+          sudo unzip -o "$PROTOC_ZIP" -d /usr/local bin/protoc
+          sudo unzip -o "$PROTOC_ZIP" -d /usr/local 'include/*'
+          rm -f "$PROTOC_ZIP"
+          
+          # Verify installation
+          protoc --version
       - name: protoc-gen deps
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26


### PR DESCRIPTION
 
###  **Detailed Description**

This PR resolves the ARM64 compatibility issue in GitHub Actions workflows that prevented local CI testing on Apple M1/M2 Macs and ARM64 systems using the `act` tool.

#### **Problem**
- The `arduino/setup-protoc@v1` action contained x86_64-specific binaries in its `node_modules/@actions/tool-cache/scripts/externals/` directory
- When running CI locally on ARM64 systems, users encountered: `qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory`
- This blocked local development and testing workflows for ARM64 users

#### **Solution**
Replaced the problematic action with a robust shell script that:

1. **Auto-detects system architecture**:
   - `x86_64` → Downloads `protoc-25.1-linux-x86_64.zip`
   - `aarch64`/`arm64` → Downloads `protoc-25.1-linux-aarch_64.zip`
   - Graceful error handling for unsupported architectures

2. ** Direct installation from official releases**:
   - Downloads from `https://github.com/protocolbuffers/protobuf/releases/`
   - Installs to `/usr/local/bin/protoc` with proper includes
   - Verifies installation with `protoc --version`

3. ** Upgraded to latest stable protoc v25.1**

###  **Files Changed**

| File | Change Description |
|------|-------------------|
| `.github/workflows/ci-go-cover.yml` |  Replaced arduino action with cross-platform script |
| `.github/workflows/ci.yml` | Replaced arduino action with cross-platform script |
| `.github/workflows/linters.yml` |  Replaced arduino action with cross-platform script |
| `.github/workflows/time-package.yml` |  Replaced arduino action with cross-platform script |
| `.github/workflows/PROTOC_FIX.md` |  Added comprehensive documentation |

###  **Testing**

-  **Architecture Detection**: Validated logic for x86_64, aarch64, and arm64
-  **URL Validation**: Confirmed official release URLs exist for both architectures
-  **Installation Test**: Successfully installed protoc v25.1 on current system
-  **Compatibility**: Maintains backward compatibility with existing workflows

 