### PR TITLE
fix(vts): add details to ValidateEvidenceIntegrity failure

### DIFF
--- a/integration-tests/data/results/cca.freshness-fail.json
+++ b/integration-tests/data/results/cca.freshness-fail.json
@@ -13,7 +13,7 @@
       "storage-opaque": 99
     },
     "ear.veraison.policy-claims": {
-      "problem": "integrity validation failed"
+      "problem": "integrity validation failed: bad evidence: freshness: realm challenge (6f24d6b9635a2c8bbf58e908b94e04c1bfb3ae80cdebe832424578499fe31761e7f5e1d8bce0121844f54abdfa5286da88f53a657b15335c9396b4329254bc5c) does not match session nonce (75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6d)"
     }
   }
 }

--- a/integration-tests/data/results/psa.badcrypto.json
+++ b/integration-tests/data/results/psa.badcrypto.json
@@ -13,7 +13,7 @@
     },
     "ear.appraisal-policy-id": "policy:PSA_IOT",
     "ear.veraison.policy-claims": {
-      "problem": "integrity validation failed"
+      "problem": "integrity validation failed: bad evidence: signature verification failed: verification error"
     }
   }
 }

--- a/integration-tests/data/results/psa.freshness-fail.json
+++ b/integration-tests/data/results/psa.freshness-fail.json
@@ -13,7 +13,7 @@
       "storage-opaque": 99
     },
     "ear.veraison.policy-claims": {
-      "problem": "integrity validation failed"
+      "problem": "integrity validation failed: bad evidence: freshness: psa-nonce (414a7c174141b3d0e9a1d28af31520f0d42299feac4007ded89d68ae6cd92f19) does not match session nonce (75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e69d6de79f75e6)"
     }
   }
 }

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -454,8 +454,17 @@ func (o *GRPC) GetAttestation(
 
 	if err = handler.ValidateEvidenceIntegrity(token, tas, multEndorsements); err != nil {
 		if errors.Is(err, handlermod.BadEvidenceError{}) {
+			var (
+				claimStr string
+				badErr   handlermod.BadEvidenceError
+			)
+			claimStr = "integrity validation failed"
+			ok := errors.As(err, &badErr)
+			if ok {
+				claimStr = fmt.Sprintf("integrity validation failed: %s", badErr.ToString())
+			}
 			appraisal.SetAllClaims(ear.CryptoValidationFailedClaim)
-			appraisal.AddPolicyClaim("problem", "integrity validation failed")
+			appraisal.AddPolicyClaim("problem", claimStr)
 		}
 		return o.finalize(appraisal, err)
 	}

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -454,11 +454,8 @@ func (o *GRPC) GetAttestation(
 
 	if err = handler.ValidateEvidenceIntegrity(token, tas, multEndorsements); err != nil {
 		if errors.Is(err, handlermod.BadEvidenceError{}) {
-			var (
-				claimStr string
-				badErr   handlermod.BadEvidenceError
-			)
-			claimStr = "integrity validation failed"
+			var badErr handlermod.BadEvidenceError
+			claimStr := "integrity validation failed"
 			ok := errors.As(err, &badErr)
 			if ok {
 				claimStr += fmt.Sprintf(": %s", badErr.ToString())

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -461,7 +461,7 @@ func (o *GRPC) GetAttestation(
 			claimStr = "integrity validation failed"
 			ok := errors.As(err, &badErr)
 			if ok {
-				claimStr = fmt.Sprintf("integrity validation failed: %s", badErr.ToString())
+				claimStr += fmt.Sprintf(": %s", badErr.ToString())
 			}
 			appraisal.SetAllClaims(ear.CryptoValidationFailedClaim)
 			appraisal.AddPolicyClaim("problem", claimStr)


### PR DESCRIPTION
The server currently reports "integrity validation failed" when evidence integrity check fails, but it could provide a more detailed description of the problem.