### PR TITLE
feat(lead verifier): verification API support

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,10 +8,16 @@ import "mime"
 // parameters) and returns it in normalized form, i.e., with lowercase type,
 // subtype and, optionally, parameter name.  An error is returned if the
 // supplied media type is invalid.
-func NormalizeMediaType(mt string) (string, error) {
+// If dropParams is true, any parameters in the supplied media type are
+// discarded in the returned normalized media type.
+func NormalizeMediaType(mt string, dropParams bool) (string, error) {
 	m, p, err := mime.ParseMediaType(mt)
 	if err != nil {
 		return "", err
+	}
+
+	if dropParams {
+		p = nil
 	}
 
 	return mime.FormatMediaType(m, p), nil

--- a/capability/well-known.go
+++ b/capability/well-known.go
@@ -11,12 +11,13 @@ const (
 )
 
 type WellKnownInfo struct {
-	PublicKey    jwk.Key           `json:"ear-verification-key,omitempty"`
-	MediaTypes   []string          `json:"media-types,omitempty"`
-	Schemes      []string          `json:"attestation-schemes,omitempty"`
-	Version      string            `json:"version"`
-	ServiceState string            `json:"service-state"`
-	ApiEndpoints map[string]string `json:"api-endpoints"`
+	PublicKey                   jwk.Key           `json:"ear-verification-key,omitempty"`
+	MediaTypes                  []string          `json:"media-types,omitempty"`
+	CompositeEvidenceMediaTypes []string          `json:"composite-evidence-media-types,omitempty"`
+	Schemes                     []string          `json:"attestation-schemes,omitempty"`
+	Version                     string            `json:"version"`
+	ServiceState                string            `json:"service-state"`
+	ApiEndpoints                map[string]string `json:"api-endpoints"`
 }
 
 var ssTrans = map[string]string{
@@ -38,6 +39,7 @@ func ServiceStateToAPI(ss string) string {
 func NewWellKnownInfoObj(
 	key jwk.Key,
 	mediaTypes []string,
+	compositeEvidenceMediaTypes []string,
 	schemes []string,
 	version string,
 	serviceState string,
@@ -45,12 +47,13 @@ func NewWellKnownInfoObj(
 ) (*WellKnownInfo, error) {
 	// MUST be kept in sync with proto/state.proto
 	obj := &WellKnownInfo{
-		PublicKey:    key,
-		MediaTypes:   mediaTypes,
-		Schemes:      schemes,
-		Version:      version,
-		ServiceState: ServiceStateToAPI(serviceState),
-		ApiEndpoints: endpoints,
+		PublicKey:                   key,
+		MediaTypes:                  mediaTypes,
+		CompositeEvidenceMediaTypes: compositeEvidenceMediaTypes,
+		Schemes:                     schemes,
+		Version:                     version,
+		ServiceState:                ServiceStateToAPI(serviceState),
+		ApiEndpoints:                endpoints,
 	}
 
 	return obj, nil

--- a/management/api/handler.go
+++ b/management/api/handler.go
@@ -256,6 +256,7 @@ func (o Handler) GetManagementWellKnownInfo(c *gin.Context) {
 	obj, err := capability.NewWellKnownInfoObj(
 		nil, // key
 		nil, // media types
+		nil, // composite evidence media types
 		o.Manager.SupportedSchemes,
 		config.Version,
 		"SERVICE_STATUS_READY",

--- a/provisioning/api/handler.go
+++ b/provisioning/api/handler.go
@@ -207,7 +207,7 @@ func (o *Handler) GetWellKnownProvisioningInfo(c *gin.Context) {
 	endpoints := getProvisioningEndpoints()
 
 	// Get final object with well known information
-	obj, err := capability.NewWellKnownInfoObj(nil, mediaTypes, nil, version, state, endpoints)
+	obj, err := capability.NewWellKnownInfoObj(nil, mediaTypes, nil, nil, version, state, endpoints)
 	if err != nil {
 		ReportProblem(c,
 			http.StatusInternalServerError,

--- a/provisioning/provisioner/provisioner.go
+++ b/provisioning/provisioner/provisioner.go
@@ -27,7 +27,8 @@ func New(vtsClient vtsclient.IVTSClient) IProvisioner {
 }
 
 func (p *Provisioner) IsSupportedMediaType(mt string) (bool, error) {
-	normalizedMediaType, err := api.NormalizeMediaType(mt)
+	dropParams := false
+	normalizedMediaType, err := api.NormalizeMediaType(mt, dropParams)
 	if err != nil {
 		return false, fmt.Errorf("%w: validation failed for %s (%v)", ErrInputParam, mt, err)
 	}

--- a/verification/api/mocks/iverifier.go
+++ b/verification/api/mocks/iverifier.go
@@ -64,6 +64,21 @@ func (mr *MockIVerifierMockRecorder) GetVTSState() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVTSState", reflect.TypeOf((*MockIVerifier)(nil).GetVTSState))
 }
 
+// IsSupportedCompositeEvidenceMediaType mocks base method.
+func (m *MockIVerifier) IsSupportedCompositeEvidenceMediaType(mt string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSupportedCompositeEvidenceMediaType", mt)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsSupportedCompositeEvidenceMediaType indicates an expected call of IsSupportedCompositeEvidenceMediaType.
+func (mr *MockIVerifierMockRecorder) IsSupportedCompositeEvidenceMediaType(mt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSupportedCompositeEvidenceMediaType", reflect.TypeOf((*MockIVerifier)(nil).IsSupportedCompositeEvidenceMediaType), mt)
+}
+
 // IsSupportedMediaType mocks base method.
 func (m *MockIVerifier) IsSupportedMediaType(mt string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -79,6 +94,21 @@ func (mr *MockIVerifierMockRecorder) IsSupportedMediaType(mt interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSupportedMediaType", reflect.TypeOf((*MockIVerifier)(nil).IsSupportedMediaType), mt)
 }
 
+// ProcessCompositeEvidence mocks base method.
+func (m *MockIVerifier) ProcessCompositeEvidence(tenantID string, nonce, data []byte, mt string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessCompositeEvidence", tenantID, nonce, data, mt)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ProcessCompositeEvidence indicates an expected call of ProcessCompositeEvidence.
+func (mr *MockIVerifierMockRecorder) ProcessCompositeEvidence(tenantID, nonce, data, mt interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessCompositeEvidence", reflect.TypeOf((*MockIVerifier)(nil).ProcessCompositeEvidence), tenantID, nonce, data, mt)
+}
+
 // ProcessEvidence mocks base method.
 func (m *MockIVerifier) ProcessEvidence(tenantID string, nonce, data []byte, mt string) ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -92,6 +122,21 @@ func (m *MockIVerifier) ProcessEvidence(tenantID string, nonce, data []byte, mt 
 func (mr *MockIVerifierMockRecorder) ProcessEvidence(tenantID, nonce, data, mt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessEvidence", reflect.TypeOf((*MockIVerifier)(nil).ProcessEvidence), tenantID, nonce, data, mt)
+}
+
+// SupportedCompositeEvidenceMediaTypes mocks base method.
+func (m *MockIVerifier) SupportedCompositeEvidenceMediaTypes() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportedCompositeEvidenceMediaTypes")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SupportedCompositeEvidenceMediaTypes indicates an expected call of SupportedCompositeEvidenceMediaTypes.
+func (mr *MockIVerifierMockRecorder) SupportedCompositeEvidenceMediaTypes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedCompositeEvidenceMediaTypes", reflect.TypeOf((*MockIVerifier)(nil).SupportedCompositeEvidenceMediaTypes))
 }
 
 // SupportedMediaTypes mocks base method.

--- a/verification/verifier/iverifier.go
+++ b/verification/verifier/iverifier.go
@@ -10,6 +10,9 @@ type IVerifier interface {
 	GetVTSState() (*proto.ServiceState, error)
 	GetPublicKey() (*proto.PublicKey, error)
 	IsSupportedMediaType(mt string) (bool, error)
+	IsSupportedCompositeEvidenceMediaType(mt string) (bool, error)
 	SupportedMediaTypes() ([]string, error)
+	SupportedCompositeEvidenceMediaTypes() ([]string, error)
 	ProcessEvidence(tenantID string, nonce []byte, data []byte, mt string) ([]byte, error)
+	ProcessCompositeEvidence(tenantID string, nonce []byte, data []byte, mt string) ([]byte, error)
 }

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -424,7 +424,10 @@ func (o *GRPC) GetCompositeAttestation(
 	//		return CAR
 	//	}
 
-	return nil, errors.New("not implemented")
+	// XXX(tho) temporary stub
+	return &proto.AppraisalContext{
+		Result: []byte(`{ "hello": "composite-attestation" }`),
+	}, nil
 }
 
 func (o *GRPC) GetAttestation(
@@ -588,7 +591,13 @@ func (c *GRPC) GetSupportedCompositeEvidenceMediaTypes(context.Context, *emptypb
 	// Note: this does not go though the plugin manager as usual; it's a core
 	// VTS capability that depends on the available composite evidence parsers.
 
-	return nil, errors.New("not implemented")
+	// XXX(tho) temporary hard-coded list
+	return &proto.MediaTypeList{MediaTypes: []string{
+		"application/cmw+json",
+		"application/cmw+cbor",
+		"application/cmw+cose",
+		"application/cmw+jws",
+	}}, nil
 }
 
 func (c *GRPC) assembleCoservMediaTypes(mts []string, filter string) []string {

--- a/vtsclient/vtsclient_grpc.go
+++ b/vtsclient/vtsclient_grpc.go
@@ -277,7 +277,8 @@ func normalizeMediaTypeList(mts *proto.MediaTypeList) *proto.MediaTypeList {
 	var nmts []string // nolint:prealloc
 
 	for _, mt := range mts.GetMediaTypes() {
-		nmt, err := api.NormalizeMediaType(mt)
+		dropParams := false
+		nmt, err := api.NormalizeMediaType(mt, dropParams)
 		if err != nil {
 			// skip invalid media type
 			continue


### PR DESCRIPTION
Add transparent support for the "lead verifier" mode where the usual challenge-response API accepts verification requests for composite evidence and dispatches them to the CE handler endpoint in VTS.

The existing verification API logic is extended to:

1. Advertise collection types during content negotiation as well as via the discovery interface.
2. Recognise requests for collection types that do not have an associated scheme plugin, and forward them to the CE handler.

Fix #368 