### PR TITLE
refactor(vts): extract (reusable) appraisal logic into separate function

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Contributors to the Veraison project.
+// Copyright 2024-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package api
 

--- a/capability/well-known.go
+++ b/capability/well-known.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Contributors to the Veraison project.
+// Copyright 2023-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package capability
 

--- a/deployments/docker/src/certs/gen-certs
+++ b/deployments/docker/src/certs/gen-certs
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2024 Contributors to the Veraison project. SPDX-License-Identifier: Apache-2.0
+# Copyright 2024-2026 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
 set -e
 

--- a/management/api/handler.go
+++ b/management/api/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Contributors to the Veraison project.
+// Copyright 2023-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
 package api

--- a/policy/agent.go
+++ b/policy/agent.go
@@ -75,10 +75,9 @@ func (o *Agent) Evaluate(
 	policy *Policy,
 	submod string,
 	appraisal *ear.Appraisal,
-	endorsements []*comid.ValueTriple,
 ) (*ear.Appraisal, error) {
 
-	endorsementMaps, err := endorsementsToMaps(endorsements)
+	endorsementMaps, err := endorsementsToMaps(appraisalContext.Endorsements)
 	if err != nil {
 		return nil, err
 	}

--- a/policy/agent_test.go
+++ b/policy/agent_test.go
@@ -147,10 +147,11 @@ func Test_Agent_Evaluate(t *testing.T) {
 		Rules:    "",
 	}
 
-	endorsements := []*comid.ValueTriple{}
 	contraStatus := ear.TrustTierContraindicated
 	polID := "policy:test-scheme"
-	appraisalContext := &appraisal.Context{}
+	appraisalContext := &appraisal.Context{
+		Endorsements: []*comid.ValueTriple{},
+	}
 	appraisal := &ear.Appraisal{
 		Status:            &contraStatus,
 		TrustVector:       &ear.TrustVector{},
@@ -182,7 +183,6 @@ func Test_Agent_Evaluate(t *testing.T) {
 			policy,
 			"test",
 			appraisal,
-			endorsements,
 		)
 
 		if v.ExpectedError == "" {

--- a/policy/iagent.go
+++ b/policy/iagent.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	"github.com/spf13/viper"
-	"github.com/veraison/corim/comid"
 	"github.com/veraison/ear"
 	"github.com/veraison/services/vts/appraisal"
 )
@@ -20,7 +19,6 @@ type IAgent interface {
 		policy *Policy,
 		submod string,
 		appraisal *ear.Appraisal,
-		endorsements []*comid.ValueTriple,
 	) (*ear.Appraisal, error)
 	Validate(ctx context.Context, policyRules string) error
 	Close()

--- a/provisioning/api/handler_test.go
+++ b/provisioning/api/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package api
 

--- a/provisioning/provisioner/provisioner.go
+++ b/provisioning/provisioner/provisioner.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
 package provisioner

--- a/verification/api/handler_test.go
+++ b/verification/api/handler_test.go
@@ -1310,7 +1310,7 @@ func TestHandler_SubmitEvidence_process_composite_ok_sync(t *testing.T) { // nol
 		ProcessCompositeEvidence(tenantID, testNonce, []byte(testJSONCollectionBody), testSupportedCompositeMediaTypeA).
 		Return([]byte(testResult), nil)
 
-	h := NewHandler(sm, v)
+	h := NewHandler(sm, v, "1h")
 
 	w := httptest.NewRecorder()
 
@@ -1360,7 +1360,7 @@ func TestHandler_GetWellKnownVerificationInfo_with_composite_ok(t *testing.T) {
 		ApiEndpoints:                publicApiMap,
 	}
 
-	h := NewHandler(sm, v)
+	h := NewHandler(sm, v, "1h")
 
 	w := httptest.NewRecorder()
 

--- a/verification/verifier/iverifier.go
+++ b/verification/verifier/iverifier.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package verifier
 

--- a/verification/verifier/verifier.go
+++ b/verification/verifier/verifier.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package verifier
 

--- a/vts/appraisal/context.go
+++ b/vts/appraisal/context.go
@@ -29,6 +29,7 @@ type Context struct {
 	Claims            map[string]any         `json:"claims"`
 	Result            *ear.AttestationResult `json:"result"`
 	SignedEAR         []byte                 `json:"signed-ear"`
+	Endorsements      []*comid.ValueTriple   `json:"endorsements"`
 }
 
 // NewContext instantiates a new Context using the provided evidence. The

--- a/vts/policymanager/mocks/iagent.go
+++ b/vts/policymanager/mocks/iagent.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	viper "github.com/spf13/viper"
-	comid "github.com/veraison/corim/comid"
 	ear "github.com/veraison/ear"
 	policy "github.com/veraison/services/policy"
 	appraisal "github.com/veraison/services/vts/appraisal"
@@ -52,18 +51,18 @@ func (mr *MockIAgentMockRecorder) Close() *gomock.Call {
 }
 
 // Evaluate mocks base method.
-func (m *MockIAgent) Evaluate(ctx context.Context, sessionContext map[string]any, appraisalContext *appraisal.Context, policy *policy.Policy, submod string, appraisal *ear.Appraisal, endorsements []*comid.ValueTriple) (*ear.Appraisal, error) {
+func (m *MockIAgent) Evaluate(ctx context.Context, sessionContext map[string]any, appraisalContext *appraisal.Context, policy *policy.Policy, submod string, appraisal *ear.Appraisal) (*ear.Appraisal, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Evaluate", ctx, sessionContext, appraisalContext, policy, submod, appraisal, endorsements)
+	ret := m.ctrl.Call(m, "Evaluate", ctx, sessionContext, appraisalContext, policy, submod, appraisal)
 	ret0, _ := ret[0].(*ear.Appraisal)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Evaluate indicates an expected call of Evaluate.
-func (mr *MockIAgentMockRecorder) Evaluate(ctx, sessionContext, appraisalContext, policy, submod, appraisal, endorsements interface{}) *gomock.Call {
+func (mr *MockIAgentMockRecorder) Evaluate(ctx, sessionContext, appraisalContext, policy, submod, appraisal interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Evaluate", reflect.TypeOf((*MockIAgent)(nil).Evaluate), ctx, sessionContext, appraisalContext, policy, submod, appraisal, endorsements)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Evaluate", reflect.TypeOf((*MockIAgent)(nil).Evaluate), ctx, sessionContext, appraisalContext, policy, submod, appraisal)
 }
 
 // GetBackendName mocks base method.

--- a/vts/policymanager/policymanager.go
+++ b/vts/policymanager/policymanager.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"github.com/spf13/viper"
-	"github.com/veraison/corim/comid"
 	"github.com/veraison/services/policy"
 	"github.com/veraison/services/vts/appraisal"
 	"go.uber.org/zap"
@@ -36,7 +35,6 @@ func New(v *viper.Viper, store *policy.Store, logger *zap.SugaredLogger) (*Polic
 func (o *PolicyManager) Evaluate(
 	ctx context.Context,
 	appraisalContext *appraisal.Context,
-	endorsements []*comid.ValueTriple,
 ) error {
 	policyKey := o.getPolicyKey(appraisalContext)
 
@@ -62,7 +60,6 @@ func (o *PolicyManager) Evaluate(
 			pol,
 			submodName,
 			submodAppraisal,
-			endorsements,
 		)
 		if err != nil {
 			return err

--- a/vts/policymanager/policymanager_test.go
+++ b/vts/policymanager/policymanager_test.go
@@ -103,7 +103,6 @@ func TestPolicyMgr_Evaluate_OK(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	polID := "policy:TPM_ENACTTRUST"
-	endorsements := []*comid.ValueTriple{}
 	ar := ear.NewAttestationResult("test", "test", "test")
 	tier := ear.TrustTierAffirming
 	earAp := ear.Appraisal{Status: &tier, AppraisalPolicyID: &polID}
@@ -112,7 +111,8 @@ func TestPolicyMgr_Evaluate_OK(t *testing.T) {
 		Evidence: &appraisal.Evidence{
 			TenantID: "0",
 		},
-		Result: ar,
+		Result:       ar,
+		Endorsements: []*comid.ValueTriple{},
 	}
 
 	store := mock_deps.NewMockIKVStore(ctrl)
@@ -130,7 +130,6 @@ func TestPolicyMgr_Evaluate_OK(t *testing.T) {
 			gomock.Any(),
 			"test",
 			ar.Submods["test"],
-			endorsements,
 		).
 		Return(&earAp, nil)
 
@@ -139,7 +138,7 @@ func TestPolicyMgr_Evaluate_OK(t *testing.T) {
 		Agent:  agent,
 		logger: log.Named("manager"),
 	}
-	err := pm.Evaluate(context.TODO(), appraisalContext, endorsements)
+	err := pm.Evaluate(context.TODO(), appraisalContext)
 	require.NoError(t, err)
 }
 
@@ -155,13 +154,13 @@ func TestPolicyMgr_Evaluate_NOK(t *testing.T) {
 	expectedErr := errors.New("could not evaluate policy: policy returned bad update")
 	agent := mock_deps.NewMockIAgent(ctrl)
 	agent.EXPECT().GetBackendName().Return("opa")
-	endorsements := []*comid.ValueTriple{}
 	appraisalContext := &appraisal.Context{
 		Scheme: "TPM_ENACTTRUST",
 		Evidence: &appraisal.Evidence{
 			TenantID: "0",
 		},
-		Result: ar,
+		Result:       ar,
+		Endorsements: []*comid.ValueTriple{},
 	}
 
 	agent.EXPECT().Evaluate(
@@ -171,7 +170,6 @@ func TestPolicyMgr_Evaluate_NOK(t *testing.T) {
 		gomock.Any(),
 		"test",
 		ar.Submods["test"],
-		endorsements,
 	).Return(nil, expectedErr)
 
 	pm := &PolicyManager{
@@ -179,7 +177,7 @@ func TestPolicyMgr_Evaluate_NOK(t *testing.T) {
 		Agent:  agent,
 		logger: log.Named("manager"),
 	}
-	err := pm.Evaluate(context.TODO(), appraisalContext, endorsements)
+	err := pm.Evaluate(context.TODO(), appraisalContext)
 	assert.ErrorIs(t, err, expectedErr)
 
 }

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -416,10 +416,9 @@ func (o *GRPC) GetCompositeAttestation(
 	}, nil
 }
 
-func (o *GRPC) GetAttestation(
-	ctx context.Context,
+func (o *GRPC) getAttestation(
 	token *proto.AttestationToken,
-) (*proto.AppraisalContext, error) {
+) (*appraisal.Context, error) {
 	evidence := appraisal.NewEvidenceFromProtobuf(token)
 	o.logger.Infow("get attestation", "media-type", evidence.MediaType,
 		"tenant-id", evidence.TenantID)
@@ -430,11 +429,11 @@ func (o *GRPC) GetAttestation(
 	if err != nil {
 		appraisal.SetAllClaims(ear.UnexpectedEvidenceClaim)
 		appraisal.AddPolicyClaim("problem", "could not resolve media type")
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 
 	if err := appraisal.SetScheme(handler.GetAttestationScheme()); err != nil {
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 
 	appraisal.TrustAnchorIDs, err = handler.GetTrustAnchorIDs(evidence)
@@ -444,7 +443,7 @@ func (o *GRPC) GetAttestation(
 			appraisal.AddPolicyClaim("problem", "could not establish identity from evidence")
 		}
 
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 
 	// TODO(setrofim): in principle, we should be matching exactly
@@ -477,7 +476,7 @@ func (o *GRPC) GetAttestation(
 			appraisal.AddPolicyClaim("problem", "no trust anchor for evidence")
 		}
 
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 
 	claims, err := handler.ExtractClaims(appraisal.Evidence, trustAnchors)
@@ -485,13 +484,13 @@ func (o *GRPC) GetAttestation(
 		if errors.Is(err, handlermod.BadEvidenceError{}) {
 			appraisal.AddPolicyClaim("problem", err.Error())
 		}
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 	appraisal.Claims = claims
 
 	appraisal.ReferenceValueIDs, err = handler.GetReferenceValueIDs(trustAnchors, claims)
 	if err != nil {
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 
 	o.logger.Debugw("constructed evidence context",
@@ -501,8 +500,11 @@ func (o *GRPC) GetAttestation(
 	o.logger.Debug("obtaining endorsements...")
 	endorsements, err := o.getValueTriples(appraisal.ReferenceValueIDs, appraisal.StoreLabel(), true)
 	if err != nil {
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
+
+	// set endorsements in appraisal context for use in policy evaluation
+	appraisal.Endorsements = endorsements
 
 	o.logger.Debug("validating evidence...")
 	if err = handler.ValidateEvidenceIntegrity(appraisal.Evidence, trustAnchors, endorsements); err != nil {
@@ -519,20 +521,33 @@ func (o *GRPC) GetAttestation(
 			appraisal.AddPolicyClaim("problem", claimStr)
 		}
 
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 
 	o.logger.Debug("appraising claims...")
 	appraisedResult, err := handler.AppraiseClaims(claims, endorsements)
 	if err != nil {
-		return o.finalize(appraisal, err)
+		return appraisal, err
 	}
 	appraisedResult.Nonce = appraisal.Result.Nonce
 	appraisal.Result = appraisedResult
+
+	return appraisal, nil
+}
+
+func (o *GRPC) GetAttestation(
+	ctx context.Context,
+	token *proto.AttestationToken,
+) (*proto.AppraisalContext, error) {
+	appraisal, err := o.getAttestation(token)
+	if err != nil {
+		return o.finalize(appraisal, err)
+	}
+
 	appraisal.InitPolicyID()
 
 	o.logger.Debug("evaluating policy...")
-	err = o.PolicyManager.Evaluate(ctx, appraisal, endorsements)
+	err = o.PolicyManager.Evaluate(ctx, appraisal)
 	if err != nil {
 		return o.finalize(appraisal, err)
 	}

--- a/vtsclient/vtsclient_grpc.go
+++ b/vtsclient/vtsclient_grpc.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package vtsclient
 


### PR DESCRIPTION
Extract (most) of the appraisal logic from `GRPC::GetAttestation()` into `GRPC::getAttestation()` so that it can be reused from other RPC service endpoints, e.g., when appraising composite evidence.