### PR TITLE
Plugin initialization and configuration

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,9 +22,6 @@ jobs:
     - name: Install guru
       run: |
         go install golang.org/x/tools/cmd/guru@latest
-    - name: Install golangci-lint
-      run: |
-        go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -39,4 +36,4 @@ jobs:
       run: |
         go install github.com/yoheimuta/protolint/cmd/protolint@v0.43.2
     - name: Run required linters in .golangci.yml plus hard-coded ones here
-      run: make -w GOLINT=$(go env GOPATH)/bin/golangci-lint lint
+      run: make -w lint

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ perf/reports/2025-02/images/3p3v
 perf/reports/2025-02/images/auto
 perf/reports/2025-02/images/comp-3v1
 perf/reports/2025-02/images/weights
+
+# tools-bin directory is created automatically when running make. It contains
+# pre-built tools needs for the make process (such as golanci-lint)
+tools-bin/*

--- a/builtin/builtin_loader.go
+++ b/builtin/builtin_loader.go
@@ -18,6 +18,8 @@ type BuiltinLoader struct {
 	loadedByName      map[string]plugin.IPluggable
 	loadedByMediaType map[string]plugin.IPluggable
 
+	pluginParams map[string]*plugin.Parameters
+
 	registeredPluginTypes map[string]string
 }
 
@@ -26,15 +28,17 @@ func NewBuiltinLoader(logger *zap.SugaredLogger) *BuiltinLoader {
 }
 
 func CreateBuiltinLoader(
-	cfg map[string]interface{},
+	cfg map[string]any,
+	pluginParams map[string]*plugin.Parameters,
 	logger *zap.SugaredLogger,
 ) (*BuiltinLoader, error) {
 	loader := NewBuiltinLoader(logger)
-	err := loader.Init(cfg)
+	err := loader.Init(cfg, pluginParams)
 	return loader, err
 }
 
-func (o *BuiltinLoader) Init(m map[string]interface{}) error {
+func (o *BuiltinLoader) Init(m map[string]any, pluginParams map[string]*plugin.Parameters) error {
+	o.pluginParams = pluginParams
 	o.loadedByName = map[string]plugin.IPluggable{}
 
 	o.loadedByMediaType = make(map[string]plugin.IPluggable)
@@ -79,6 +83,17 @@ func DiscoverBuiltinUsing[I plugin.IPluggable](loader *BuiltinLoader) error {
 		name := p.GetName()
 		if _, ok := loader.loadedByName[name]; ok {
 			loader.logger.Panicw("duplicate plugin name", "name", name)
+		}
+
+		var params *plugin.Parameters
+		if params, ok = loader.pluginParams[name]; !ok {
+			params = plugin.NewParameters()
+		}
+
+		loader.logger.Debugw("initializing plugin", "plugin", name, "params", params.Map())
+		if err := p.Init(params); err != nil {
+			loader.logger.Errorf("plugin q: %s", name, err.Error())
+			continue
 		}
 
 		loader.logger.Debugw("found plugin", "name", name)

--- a/builtin/builtin_manager.go
+++ b/builtin/builtin_manager.go
@@ -23,6 +23,7 @@ func NewBuiltinManager[I plugin.IPluggable](
 
 func CreateBuiltinManager[I plugin.IPluggable](
 	v *viper.Viper,
+	pluginParams map[string]*plugin.Parameters,
 	logger *zap.SugaredLogger,
 	name string,
 ) (*BuiltinManager[I], error) {
@@ -31,7 +32,7 @@ func CreateBuiltinManager[I plugin.IPluggable](
 		return nil, err
 	}
 
-	loader, err := CreateBuiltinLoader(subs["builtin"].AllSettings(), logger)
+	loader, err := CreateBuiltinLoader(subs["builtin"].AllSettings(), pluginParams, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/handler/coservproxy_rpc.go
+++ b/handler/coservproxy_rpc.go
@@ -28,6 +28,21 @@ type CoservProxyRPCServer struct {
 	Impl ICoservProxyHandler
 }
 
+func (o *CoservProxyRPCServer) Init(args []byte, resp *any) error {
+	var params *plugin.Parameters
+	var err error
+
+	if args == nil {
+		params = plugin.NewParameters()
+	} else {
+		if params, err = plugin.ParametersFromJSON(args); err != nil {
+			return err
+		}
+	}
+
+	return o.Impl.Init(params)
+}
+
 func (s *CoservProxyRPCServer) GetName(args interface{}, resp *string) error {
 	*resp = s.Impl.GetName()
 	return nil
@@ -58,6 +73,22 @@ func (s *CoservProxyRPCServer) GetEndorsements(args GetEndorsementArgs, resp *[]
 
 type CoservProxyRPCClient struct {
 	client *rpc.Client
+}
+
+func (o *CoservProxyRPCClient) Init(params *plugin.Parameters) error {
+	var (
+		unused any
+		args []byte
+		err error
+	)
+
+	if params != nil {
+		if args, err = params.MarshalJSON(); err != nil {
+			return err
+		}
+	}
+
+	return o.client.Call("Plugin.Init", args, &unused)
 }
 
 func (c *CoservProxyRPCClient) GetName() string {

--- a/handler/scheme_rpc.go
+++ b/handler/scheme_rpc.go
@@ -37,6 +37,22 @@ type SchemeRPCClient struct {
 	logger *zap.SugaredLogger
 }
 
+func (o *SchemeRPCClient) Init(params *plugin.Parameters) error {
+	var (
+		unused any
+		args []byte
+		err error
+	)
+
+	if params != nil {
+		if args, err = params.MarshalJSON(); err != nil {
+			return err
+		}
+	}
+
+	return o.client.Call("Plugin.Init", args, &unused)
+}
+
 func (o *SchemeRPCClient) GetName() string {
 	var (
 		unused any
@@ -263,6 +279,21 @@ func (o *SchemeRPCClient) AppraiseClaims(
 
 type SchemeRPCServer struct {
 	Impl ISchemeHandler
+}
+
+func (o *SchemeRPCServer) Init(args []byte, resp *any) error {
+	var params *plugin.Parameters
+	var err error
+
+	if args == nil {
+		params = plugin.NewParameters()
+	} else {
+		if params, err = plugin.ParametersFromJSON(args); err != nil {
+			return err
+		}
+	}
+
+	return o.Impl.Init(params)
 }
 
 func (o *SchemeRPCServer) GetName(unused any, resp *string) error {

--- a/handler/schemeimplementationwrapper.go
+++ b/handler/schemeimplementationwrapper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/veraison/corim/comid"
 	"github.com/veraison/corim/corim"
 	"github.com/veraison/ear"
+	"github.com/veraison/services/plugin"
 	"github.com/veraison/services/vts/appraisal"
 )
 
@@ -46,9 +47,19 @@ func MustNewSchemeImplementationWrapper(
 	return ret
 }
 
+func (o *SchemeImplementationWrapper) Init(params *plugin.Parameters) error {
+	pluginImpl, ok := o.Impl.(interface {
+		Init(*plugin.Parameters) error
+	})
+	if ok {
+		return pluginImpl.Init(params)
+	}
+
+	return nil
+}
+
 func (o *SchemeImplementationWrapper) GetName() string {
-	name := strings.ToLower(strings.ReplaceAll(o.Desc.Name, " ", "-"))
-	return fmt.Sprintf("%s-scheme-plugin", name)
+	return PluginNameFromScheme(o.Desc.Name)
 }
 
 func (o *SchemeImplementationWrapper) GetAttestationScheme() string {

--- a/handler/util.go
+++ b/handler/util.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package handler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PluginNameFromScheme generates a plugin name from an attestations scheme
+// name.
+func PluginNameFromScheme(schemeName string) string {
+	name := strings.ToLower(strings.ReplaceAll(schemeName, " ", "-"))
+	return fmt.Sprintf("%s-scheme-plugin", name)
+}

--- a/management/policy.go
+++ b/management/policy.go
@@ -24,7 +24,7 @@ type PolicyManager struct {
 }
 
 func CreatePolicyManagerFromConfig(v *viper.Viper, name string) (*PolicyManager, error) {
-	subs, err := config.GetSubs(v, "*po-agent", "po-store", "*plugin")
+	subs, err := config.GetSubs(v, "*po-agent", "po-store", "*plugin", "*scheme")
 	if err != nil {
 		return nil, err
 	}
@@ -39,18 +39,23 @@ func CreatePolicyManagerFromConfig(v *viper.Viper, name string) (*PolicyManager,
 		return nil, err
 	}
 
+	pluginConfig, err := plugin.ParametersMapFromViper(subs["scheme"], handler.PluginNameFromScheme)
+	if err != nil {
+		return nil, err
+	}
+
 	var pluginManager plugin.IManager[handler.ISchemeHandler]
 
 	if config.SchemeLoader == "plugins" { // nolint:gocritic
 		pluginManager, err = plugin.CreateGoPluginManager(
-			subs["plugin"], log.Named("plugin"),
+			subs["plugin"], pluginConfig, log.Named("plugin"),
 			"scheme-handler", handler.SchemeHandlerRPC)
 		if err != nil {
 			log.Fatalf("plugin manager initialization failed: %v", err)
 		}
 	} else if config.SchemeLoader == "builtin" {
 		pluginManager, err = builtin.CreateBuiltinManager[handler.ISchemeHandler](
-			subs["plugin"], log.Named("builtin"), "scheme-handler")
+			subs["plugin"], pluginConfig, log.Named("builtin"), "scheme-handler")
 		if err != nil {
 			log.Fatalf("scheme manager initialization failed: %v", err)
 		}

--- a/mk/lint.mk
+++ b/mk/lint.mk
@@ -1,18 +1,26 @@
-# Copyright 2021 Contributors to the Veraison project.
+# Copyright 2021-2026 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
 #
 # variables:
-# * GOLINT - name of the linter package
 # * GOLINT_ARGS - command line arguments for $(LINT) when run on the lint target
 # targets:
 # * lint  - run source code linter
 
-GOLINT ?= golangci-lint
-
 GOLINT_ARGS ?= run --timeout=3m -E dupl -E gocritic -E gosimple -E prealloc
 
+GOLINT_VERSION = v1.64.8
+GOLINT = $(TOPDIR)/tools-bin/golangci-lint
+GOLINT_STAMP = $(TOPDIR)/tools-bin/golangci-lint-$(GOLINT_VERSION).stamp
+
+$(GOLINT): $(GOLINT_STAMP)
+
+$(GOLINT_STAMP):
+	mkdir -p $(dir $(GOLINT))
+	touch $(GOLINT_STAMP)
+	GOBIN=$(dir $(GOLINT)) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLINT_VERSION)
+
 .PHONY: lint
-lint: lint-hook-pre reallint
+lint: $(GOLINT) lint-hook-pre reallint
 
 .PHONY: lint-hook-pre
 lint-hook-pre:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,6 +20,7 @@ All Veraison plugins must implement the `IPluggable` interface:
 ```go
 
 type IPluggable interface {
+	Init(*Parameters) error
 	GetName() string
 	GetAttestationScheme() string
 	GetSupportedMediaTypes() []string
@@ -98,6 +99,7 @@ import (
 
 type Impl struct {}
 
+func (o *Impl) Init(*plugin.Parameters) error { return nil }
 func (o *Impl) GetName() string { return "my-implementation" }
 func (o *Impl) GetAttestationScheme() string { return "my-scheme" }
 func (o *Impl) GetSupportedMediaTypes() []string { return []string{"text/html"} }
@@ -163,5 +165,47 @@ func main() {
 
     // use your plugin
     impl.Method1()
+}
+```
+
+## Plugin initialization and configuration
+
+Each plugin's `Init()` method is called when the plugin is discovered and
+loaded by the loader. This is the only method of `IPluggable` that gets
+invoked regardless of whether or not a plugin is actually used. This provides
+an opportunity for early one-time initialization of a plugin.
+
+If `Init()` return an error, this error will be reported  by loader and the
+plugin will not be loaded and will not be available for use later. This,
+however, will not result in process termination, and the loader will continue
+to load other plugins.
+
+Plugins can obtain configuration settings by querying `*Parameters` passed to
+their `Init()`. `Parameters` are populated from service configuration. Please
+see the [VTS service documentation](/vts/cmd/vts-service/README.md) for
+specifics.
+
+For example
+
+```go
+
+const defaultTimeout = 10
+
+func (o *Impl) Init(params *plugin.Parameters) error {
+    url, err := params.GetString("service_url")
+    if err != nil {
+        // "service_url" not set or is not a string
+        return err
+    }
+    o.serviceURL = url // will be used by Impl's other methods
+
+    timeout, err := params.DefaultGetInt("timeout", defaultTimeout)
+    if err != nil {
+        // "timeout" is set but is not an int
+        return err
+    }
+    o.timeout = timeout // will be used by Impl's other methods
+
+    return nil
 }
 ```

--- a/plugin/goplugin_loader.go
+++ b/plugin/goplugin_loader.go
@@ -37,6 +37,8 @@ type GoPluginLoader struct {
 	// This gets specified as Plugins when creating a new go-plugin client.
 	pluginMap map[string]plugin.Plugin
 
+	pluginParams map[string]*Parameters
+
 	registeredPluginTypes map[string]string
 }
 
@@ -45,15 +47,17 @@ func NewGoPluginLoader(logger *zap.SugaredLogger) *GoPluginLoader {
 }
 
 func CreateGoPluginLoader(
-	cfg map[string]interface{},
+	cfg map[string]any,
+	pluginParams map[string]*Parameters,
 	logger *zap.SugaredLogger,
 ) (*GoPluginLoader, error) {
 	loader := NewGoPluginLoader(logger)
-	err := loader.Init(cfg)
+	err := loader.Init(cfg, pluginParams)
 	return loader, err
 }
 
-func (o *GoPluginLoader) Init(m map[string]interface{}) error {
+func (o *GoPluginLoader) Init(m map[string]any, pluginParams map[string]*Parameters) error {
+	o.pluginParams = pluginParams
 	o.pluginMap = make(map[string]plugin.Plugin)
 	o.loadedByName = make(map[string]IPluginContext)
 	o.loadedByMediaType = make(map[string]IPluginContext)
@@ -98,8 +102,8 @@ func (o *GoPluginLoader) GetRegisteredMediaTypesByPluginType(typeName string) []
 	return mediaTypes
 }
 
-func Init(m map[string]interface{}) error {
-	return defaultGoPluginLoader.Init(m)
+func Init(m map[string]any, pluginParams map[string]*Parameters) error {
+	return defaultGoPluginLoader.Init(m, pluginParams)
 }
 
 func RegisterGoPlugin[I IPluggable](name string, ch *RPCChannel[I]) error {
@@ -112,7 +116,7 @@ func RegisterGoPluginUsing[I IPluggable](
 	ch *RPCChannel[I],
 ) error {
 	if _, ok := loader.pluginMap[name]; ok {
-		return fmt.Errorf("plugin for %q is already registred", name)
+		return fmt.Errorf("plugin for %q is already registered", name)
 	}
 
 	if err := registerRPCChannel(name, ch); err != nil {
@@ -161,6 +165,19 @@ func DiscoverGoPluginUsing[I IPluggable](o *GoPluginLoader) error {
 				pluginContext.GetPath(),
 			)
 		}
+
+		var params *Parameters
+		var ok bool
+		if params, ok = o.pluginParams[pluginName]; !ok {
+			params = NewParameters()
+		}
+
+		o.logger.Debugw("initializing plugin", "plugin", pluginName, "params", params.Map())
+		if err := pluginContext.Handle.Init(params); err != nil {
+			o.logger.Errorf("plugin q: %s", pluginName, err.Error())
+			continue
+		}
+
 		o.loadedByName[pluginName] = pluginContext
 
 		for _, mediaTypes := range pluginContext.SupportedMediaTypes {

--- a/plugin/goplugin_manager.go
+++ b/plugin/goplugin_manager.go
@@ -28,6 +28,7 @@ func NewGoPluginManager[I IPluggable](
 
 func CreateGoPluginManager[I IPluggable](
 	v *viper.Viper,
+	pluginParams map[string]*Parameters,
 	logger *zap.SugaredLogger,
 	name string,
 	ch *RPCChannel[I],
@@ -38,7 +39,7 @@ func CreateGoPluginManager[I IPluggable](
 		return nil, err
 	}
 
-	loader, err := CreateGoPluginLoader(subs["go-plugin"].AllSettings(), logger)
+	loader, err := CreateGoPluginLoader(subs["go-plugin"].AllSettings(), pluginParams, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/ipluggable.go
+++ b/plugin/ipluggable.go
@@ -6,6 +6,12 @@ package plugin
 // the common interfaces shared by all Veraison plugins loaded through this
 // framework.
 type IPluggable interface {
+	// Init performs plugin initialization using parameters provided by
+	// configuration. This method is always invoked by the IPluginLoader
+	// implementation when the plugin is loaded, and should not, in general,
+	// be invoked by the plugin's user or anyone else.
+	Init(params *Parameters) error
+
 	// GetName returns a string containing the name of the
 	// implementation of this IPluggable interface. It is the plugin name.
 	GetName() string

--- a/plugin/parameters.go
+++ b/plugin/parameters.go
@@ -1,0 +1,411 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package plugin
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+
+	"github.com/spf13/viper"
+)
+
+var (
+	ErrNotSet = errors.New("parameter not set")
+	ErrInvalid = errors.New("invalid parameter value")
+)
+
+// ParametersMapFromViper constructs a map[string]*Parameters from the
+// provided *viper.Viper, where the top-level entries in the Viper become
+// map keys and the corresponding nested entries are used to construct
+// the Parameters.
+// If keyTrans function is not nil, then it is called for each top-level
+// Viper entry, and the output is used as map keys, rather than using the
+// entry directly.
+//
+// For example:
+//
+//   v := viper.New()
+//   v.Set("s1.p1", "foo")
+//   v.Set("s2.p1", 1)
+//   m1, err := ParametersMapFromViper(v, func(n string) string { return strings.ToUpper(n) })
+//
+//   m2 := map[string]*Parameters{
+//       "S1": NewParameters().SetString("p1", "foo"),
+//       "S2": NewParameters().SetInt("p1", 1),
+//   }
+//
+// m1 and m2 above are equivalent.
+func ParametersMapFromViper(v *viper.Viper, keyTrans func(string)string) (map[string]*Parameters, error) {
+	ret := make(map[string]*Parameters)
+	if v == nil {
+		return ret, nil
+	}
+
+	for key := range v.AllSettings() {
+		if sub := v.Sub(key); sub != nil {
+			params, err := ParametersFromViper(sub)
+			if err != nil {
+				return nil, fmt.Errorf("entry %q: %w", key, err)
+			}
+
+			if keyTrans != nil {
+				key = keyTrans(key)
+			}
+
+			ret[key] = params
+		} else {
+			return nil, fmt.Errorf("entry %q is not a map", key)
+		}
+	}
+
+	return ret, nil
+}
+
+// ParametersFromJSON parses the provided JSON data and uses it to generate *Parameters.
+func ParametersFromJSON(data []byte) (*Parameters, error) {
+	ret := NewParameters()
+
+	if err := ret.UnmarshalJSON(data); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// ParametersFromViper generates a *Parameters from the provided *viper.Viper
+func ParametersFromViper(v *viper.Viper) (*Parameters, error) {
+	return ParametersFromMap(v.AllSettings())
+}
+
+// ParametersFromMap generates a *Parameters from the provided map[string]any
+func ParametersFromMap(m map[string]any) (*Parameters, error) {
+	ret := NewParameters()
+	if err := ret.PopulateFromMap(m); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+// Parameters represent plugin configuration settings that are passed to a
+// plugin on its initialization. These are, essentially, string keys mapping on
+// values of supported types (string, []byte, int, int64, bool).
+// Valid keys and their expected value types are plugin-specific.
+type Parameters struct {
+	values map[string]any
+}
+
+// NewParameters creates a new empty *Parameters.
+func NewParameters() *Parameters {
+	return &Parameters{
+		values: make(map[string]any),
+	}
+}
+
+// MarshalJSON serializes Parameters into a JSON object
+func (o *Parameters) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.values)
+}
+
+// UnmarshalJSON deserializes a JSON object and uses it to populate the
+// Parameters.
+func (o *Parameters) UnmarshalJSON(data []byte) error {
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return err
+	}
+
+	// use temporary intermediate so that o's original state is preserved
+	// on error
+	tmp := NewParameters()
+	for k, v := range m {
+		if err := tmp.Set(k, v); err != nil {
+			return err
+		}
+	}
+
+	o.values = tmp.values
+	return nil
+}
+
+// SetString sets the specified key to the specified string value and returns a
+// pointer to the Parameters object. If the key already exists, it is
+// overwritten.
+func (o *Parameters) SetString(key, value string) *Parameters {
+	return o.set(key, value)
+}
+
+// SetBytes sets the specified key to the specified []byte value and returns a
+// pointer to the Parameters object. If the key already exists, it is
+// overwritten.
+func (o *Parameters) SetBytes(key string, value []byte) *Parameters {
+	return o.set(key, base64.StdEncoding.EncodeToString(value))
+}
+
+// SetInt sets the specified key to the specified int value and returns a
+// pointer to the Parameters object. If the key already exists, it is
+// overwritten.
+func (o *Parameters) SetInt(key string, value int) *Parameters {
+	return o.set(key, int64(value))
+}
+
+// SetInt64 sets the specified key to the specified int64 value and returns a
+// pointer to the Parameters object. If the key already exists, it is
+// overwritten.
+func (o *Parameters) SetInt64(key string, value int64) *Parameters {
+	return o.set(key, value)
+}
+
+// SetBool sets the specified key to the specified bool value and returns a
+// pointer to the Parameters object. If the key already exists, it is
+// overwritten.
+func (o *Parameters) SetBool(key string, value bool) *Parameters {
+	return o.set(key, value)
+}
+
+// Set the specified key to the specified value, provided value is of one of
+// the supported types, otherwise ErrInvalid is returned. Supported types are
+// string, []byte, int, int64, and bool. If the key already exists, it is
+// overwritten.
+func (o *Parameters) Set(key string, value any) error {
+	switch t := value.(type) {
+	case string, []byte, int64, bool:
+		o.set(key, value)
+	case int:
+		o.set(key, int64(t))
+	case float64:
+		if t < float64(math.MinInt64) || t > float64(math.MaxInt64) {
+			return fmt.Errorf("%w for %q: out of int64 range: %v", ErrInvalid, key, t)
+		}
+
+		if t != float64(int64(t)) {
+			return fmt.Errorf("%w for %q: has fractional part: %v", ErrInvalid, key, t)
+		}
+
+		o.set(key, int64(t))
+	default:
+		return fmt.Errorf("%w for %q: %v (%T)", ErrInvalid, key, value, value)
+	}
+
+	return nil
+}
+
+// PopulateFromMap populates the Parameters from the provided map. This is
+// equivalent to calling Set for each key and corresponding value in the map.
+func (o *Parameters) PopulateFromMap(m map[string]any) error {
+	for k, v := range m {
+		if err := o.Set(k, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PopulateFromViper populates the Parameters form the provided *viper.Viper.
+// This is equivalent to first converting the Viper into a map[string]any and
+// passing it to PopulateFromMap().
+func (o *Parameters) PopulateFromViper(v *viper.Viper) error {
+	return o.PopulateFromMap(v.AllSettings())
+}
+
+// Map returns a map[string]any corresponding to the Parameters.
+func (o *Parameters) Map() map[string]any {
+	return maps.Clone(o.values)
+}
+
+// Get returns the value corresponding to the specified key, or ErrNotSet if
+// the key is not in Parameters.
+func (o *Parameters) Get(key string) (any, error) {
+	val, ok := o.values[key]
+	if ok {
+		return val, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrNotSet, key)
+}
+
+// DefaultGet returns the value corresponding to the specified key, or the
+// provided defaultValue, if the key is not in Parameters.
+func (o *Parameters) DefaultGet(key string, defaultValue any) any {
+	val, err := o.Get(key)
+	if err != nil {
+		return defaultValue
+	}
+
+	return val
+}
+
+// GetString returns the string value corresponding to the specified key. If
+// the key is not set or the value is a string, return "" and set the error to
+// ErrNotSet or ErrInvalid respectively.
+func (o *Parameters) GetString(key string) (string, error) {
+	return get(o, key, "", false)
+}
+
+// MustGetString is like GetString() but panics on error.
+func (o *Parameters) MustGetString(key string) string {
+	val, err := o.GetString(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+// DefaultGetString returns the string value corresponding to the specified
+// key. If the key is not set, defaultValue is returned instead. If the value
+// is not a string, returns "" and the error is set to ErrInvalid.
+func (o *Parameters) DefaultGetString(key, defaultValue string) (string, error) {
+	return get(o, key, defaultValue, true)
+}
+
+// GetBytes returns the []byte value corresponding to the specified key. If the
+// key is not set or the value is a []byte, return nil and set the error to
+// ErrNotSet or ErrInvalid respectively.
+func (o *Parameters) GetBytes(key string) ([]byte, error) {
+	encoded, err := o.GetString(key)
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w for %q: %q", ErrInvalid, key, encoded)
+	}
+
+	return val, nil
+}
+
+// MustGetBytes is like GetBytes() but panics on error.
+func (o *Parameters) MustGetBytes(key string) []byte {
+	val, err := o.GetBytes(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+// DefaultGetBytes returns the []byte value corresponding to the specified key.
+// If the key is not set, defaultValue is returned instead. If the value is not
+// a []byte, returns nil and the error is set to ErrInvalid.
+func (o *Parameters) DefaultGetBytes(key string, defaultValue []byte) ([]byte, error) {
+	encoded, err := o.DefaultGetString(key, "")
+	if err != nil {
+		return nil, err
+	} else if encoded == "" {
+		return defaultValue, nil
+	}
+
+	val, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("%w for %q: %q", ErrInvalid, key, encoded)
+	}
+
+	return val, nil
+}
+
+// GetInt64 returns the int64 value corresponding to the specified key. If the
+// key is not set or the value is a int64, return 0 and set the error to
+// ErrNotSet or ErrInvalid respectively.
+func (o *Parameters) GetInt64(key string) (int64, error) {
+	return get(o, key, int64(0), false)
+}
+
+// MustGetInt64 is like GetInt64() but panics on error.
+func (o *Parameters) MustGetInt64(key string) int64 {
+	val, err := o.GetInt64(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+
+// DefaultGetInt64 returns the int64 value corresponding to the specified key.
+// If the key is not set, defaultValue is returned instead. If the value is not
+// a int64, returns 0 and the error is set to ErrInvalid.
+func (o *Parameters) DefaultGetInt64(key string, defaultValue int64) (int64, error) {
+	return get(o, key, defaultValue, true)
+}
+
+// GetInt returns the int value corresponding to the specified key. If the key
+// is not set or the value is a int, return 0 and set the error to ErrNotSet or
+// ErrInvalid respectively.
+func (o *Parameters) GetInt(key string) (int, error) {
+	val, err := o.GetInt64(key)
+	return int(val), err
+}
+
+// MustGetInt is like GetInt() but panics on error.
+func (o *Parameters) MustGetInt(key string) int {
+	val, err := o.GetInt(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+// DefaultGetInt returns the int value corresponding to the specified key.
+// If the key is not set, defaultValue is returned instead. If the value is not
+// a int, returns 0 and the error is set to ErrInvalid.
+func (o *Parameters) DefaultGetInt(key string, defaultValue int) (int, error) {
+	val, err := o.DefaultGetInt64(key, int64(defaultValue))
+	return int(val), err
+}
+
+// GetBool returns the bool value corresponding to the specified key. If the
+// key is not set or the value is a bool, return false and set the error to
+// ErrNotSet or ErrInvalid respectively.
+func (o *Parameters) GetBool(key string) (bool, error) {
+	return get(o, key, false, false)
+}
+
+// MustGetBool is like GetBool() but panics on error.
+func (o *Parameters) MustGetBool(key string) bool {
+	val, err := o.GetBool(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+// DefaultGetBool returns the bool value corresponding to the specified key.
+// If the key is not set, defaultValue is returned instead. If the value is not
+// a bool, returns false and the error is set to ErrInvalid.
+func (o *Parameters) DefaultGetBool(key string, defaultValue bool) (bool, error) {
+	return get(o, key, defaultValue, true)
+}
+
+func (o *Parameters) set(key string, value any) *Parameters {
+	o.values[key] = value
+	return o
+}
+
+func get[T any](params *Parameters, key string, defaultValue T, withDefault bool) (T, error) {
+	val, err := params.Get(key)
+	if err != nil {
+		if withDefault {
+			return defaultValue, nil
+		} else {
+			return defaultValue, err
+		}
+	}
+
+	switch t := val.(type) {
+	case *T:
+		return *t, nil
+	case T:
+		return t, nil
+	default:
+		return defaultValue, fmt.Errorf("%w for %q: %v", ErrInvalid, key, val)
+	}
+}

--- a/plugin/parameters_test.go
+++ b/plugin/parameters_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package plugin
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestParameters_round_trip(t *testing.T) {
+	params := NewParameters().
+			SetString("p1", "foo").
+			SetInt("p2", 1).
+			SetInt64("p3", 2).
+			SetBytes("p4", []byte{0xde, 0xad, 0xbe, 0xef}).
+			SetBool("p5", true)
+
+	data, err := params.MarshalJSON()
+	assert.NoError(t, err)
+
+	var out Parameters
+	err = out.UnmarshalJSON(data)
+	assert.NoError(t, err)
+
+	assert.Equal(t, params.MustGetString("p1"), out.MustGetString("p1"))
+	assert.Equal(t, params.MustGetInt("p2"), out.MustGetInt("p2"))
+	assert.Equal(t, params.MustGetInt64("p3"), out.MustGetInt64("p3"))
+	assert.Equal(t, params.MustGetBytes("p4"), out.MustGetBytes("p4"))
+	assert.Equal(t, params.MustGetBool("p5"), out.MustGetBool("p5"))
+}
+
+func TestParameters_bytes(t *testing.T) {
+	bytes := []byte{0xde, 0xad, 0xbe, 0xef}
+	params := NewParameters().SetBytes("p1", bytes)
+	assert.Equal(t, bytes, params.MustGetBytes("p1"))
+}
+
+func TestParameters_float(t *testing.T) {
+	params := NewParameters()
+
+	err := params.Set("p1", 1.0)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, params.MustGetInt("p1"))
+
+	err = params.Set("p2", 1.1)
+	assert.ErrorIs(t, err, ErrInvalid)
+
+	err = params.Set("p2", 9223372036854775808.0)
+	assert.ErrorIs(t, err, ErrInvalid)
+}
+
+func TestParameters_set_get(t *testing.T) {
+	bytes := []byte{0xde, 0xad, 0xbe, 0xef}
+	params := NewParameters().SetInt("p1", 1).SetBytes("p2", bytes)
+
+	val, err := params.GetInt("p1")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, val)
+
+	_, err = params.GetString("p1")
+	assert.ErrorIs(t, err, ErrInvalid)
+
+	_, err = params.GetString("p3")
+	assert.ErrorIs(t, err, ErrNotSet)
+
+	val, err = params.DefaultGetInt("p1", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, val)
+
+	otherBytes := []byte{0x0b, 0xad, 0xf0, 0x0d}
+	val2, err := params.DefaultGetBytes("p2", otherBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, bytes, val2)
+
+	val2, err = params.DefaultGetBytes("p3", otherBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, otherBytes, val2)
+
+	_, err = params.DefaultGetInt("p2", 2)
+	assert.ErrorIs(t, err, ErrInvalid)
+
+	val3 := params.DefaultGet("p1", "foo")
+	assert.Equal(t, int64(1), val3)
+}
+
+func TestParametersFromMap(t *testing.T) {
+	m := map[string]any{
+		"p1": "foo",
+		"p2": int64(2),
+	}
+	params, err := ParametersFromMap(m)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", params.MustGetString("p1"))
+	assert.Equal(t, 2, params.MustGetInt("p2"))
+	assert.Equal(t, m, params.Map())
+
+	_, err = params.GetBool("p3")
+	assert.ErrorIs(t, err, ErrNotSet)
+
+	_, err = ParametersFromMap(map[string]any{
+		"p1": []string{"foo", "bar"},
+	})
+	assert.ErrorIs(t, err, ErrInvalid)
+}
+
+func TestParametersFromViper(t *testing.T) {
+	v := viper.New()
+	v.Set("p1", "foo")
+	v.Set("p2", 2)
+
+	params, err := ParametersFromViper(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", params.MustGetString("p1"))
+	assert.Equal(t, 2, params.MustGetInt("p2"))
+
+	_, err = params.GetBool("p3")
+	assert.ErrorIs(t, err, ErrNotSet)
+
+	v.Set("p3.a", true)
+	_, err = ParametersFromViper(v)
+	assert.ErrorIs(t, err, ErrInvalid)
+
+	err = NewParameters().PopulateFromViper(v)
+	assert.ErrorIs(t, err, ErrInvalid)
+}
+
+func TestParametersFromJSON(t *testing.T) {
+	bytes := []byte(`{"p1":"foo","p2":2}`)
+	params, err := ParametersFromJSON(bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", params.MustGetString("p1"))
+	assert.Equal(t, 2, params.MustGetInt("p2"))
+
+	_, err = params.GetBool("p3")
+	assert.ErrorIs(t, err, ErrNotSet)
+
+	bytes = []byte(`{"p1":["foo","bar"]}`)
+	err = params.UnmarshalJSON(bytes)
+	assert.ErrorIs(t, err, ErrInvalid)
+	assert.Equal(t, "foo", params.MustGetString("p1"))
+}
+
+func TestPametersMapFromViper(t *testing.T) {
+	v := viper.New()
+	v.Set("s1.p1", "foo")
+	v.Set("s1.p2", 2)
+	v.Set("s2.p1", "bar")
+	v.Set("s2.p2", "baz")
+
+	m, err := ParametersMapFromViper(v, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", m["s1"].MustGetString("p1"))
+	assert.Equal(t, 2, m["s1"].MustGetInt("p2"))
+	assert.Equal(t, "bar", m["s2"].MustGetString("p1"))
+	assert.Equal(t, "baz", m["s2"].MustGetString("p2"))
+
+	_, ok := m["p3"]
+	assert.False(t, ok)
+
+	m, err = ParametersMapFromViper(v, func(name string) string {
+		return fmt.Sprintf("%s-suffix", name)
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", m["s1-suffix"].MustGetString("p1"))
+
+	_, ok = m["p1"]
+	assert.False(t, ok)
+
+	v.Set("s3.p1.a", 1)
+	_, err = ParametersMapFromViper(v, nil)
+	assert.ErrorIs(t, err, ErrInvalid)
+}

--- a/plugin/test/ammo.go
+++ b/plugin/test/ammo.go
@@ -11,6 +11,7 @@ import (
 )
 
 type IAmmo interface {
+	Init(*plugin.Parameters) error
 	GetName() string
 	GetAttestationScheme() string
 	GetSupportedMediaTypes() map[string][]string
@@ -19,6 +20,22 @@ type IAmmo interface {
 
 type AmmoRPCClient struct {
 	client *rpc.Client
+}
+
+func (o *AmmoRPCClient) Init(params *plugin.Parameters) error {
+	var (
+		unused any
+		args []byte
+		err error
+	)
+
+	if params != nil {
+		if args, err = params.MarshalJSON(); err != nil {
+			return err
+		}
+	}
+
+	return o.client.Call("Plugin.Init", &args, &unused)
 }
 
 func (o *AmmoRPCClient) GetName() string {
@@ -88,6 +105,21 @@ func (o *AmmoRPCClient) GetCapacity() int {
 
 type AmmoRPCServer struct {
 	Impl IAmmo
+}
+
+func (o *AmmoRPCServer) Init(args *[]byte, resp *any) error {
+	var params *plugin.Parameters
+	var err error
+
+	if args == nil {
+		params = plugin.NewParameters()
+	} else {
+		if params, err = plugin.ParametersFromJSON(*args); err != nil {
+			return err
+		}
+	}
+
+	return o.Impl.Init(params)
 }
 
 func (o *AmmoRPCServer) GetName(args any, resp *string) error {

--- a/plugin/test/gascartridge/gascartridge.go
+++ b/plugin/test/gascartridge/gascartridge.go
@@ -10,6 +10,10 @@ import (
 type GasCartridge struct {
 }
 
+func (o GasCartridge) Init(*plugin.Parameters) error {
+	return nil
+}
+
 func (o GasCartridge) GetName() string {
 	return "gas cartridge"
 }

--- a/plugin/test/loader_test.go
+++ b/plugin/test/loader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package test
 
@@ -21,7 +21,12 @@ func TestLoader_discover_and_load(t *testing.T) {
 	cfg := map[string]interface{}{"dir": "bin"}
 	logger := log.Named("test")
 
-	ldr, err := plugin.CreateGoPluginLoader(cfg, logger)
+	pluginParams := map[string]*plugin.Parameters{
+		"Federation Starship Officer": plugin.NewParameters().SetString("sound", "zap"),
+		"Galactic Imperial Trooper": plugin.NewParameters().SetString("sound", "pew, pew"),
+	}
+
+	ldr, err := plugin.CreateGoPluginLoader(cfg, pluginParams, logger)
 	require.NoError(t, err)
 	defer ldr.Close()
 
@@ -40,6 +45,10 @@ func TestLoader_discover_and_load(t *testing.T) {
 	mediaTypes := ldr.GetRegisteredMediaTypes()
 	expected := []string{"blaster", "phaser", "tibanna gas", "plasma"}
 	assert.ElementsMatch(t, expected, mediaTypes)
+
+	mook, err := plugin.GetGoPluginHandleByNameUsing[IMook](ldr, "Federation Starship Officer")
+	assert.NoError(t, err)
+	assert.Equal(t, `phaser goes "zap"`, mook.Shoot())
 }
 
 func buildPlugins(names []string) error {

--- a/plugin/test/mook.go
+++ b/plugin/test/mook.go
@@ -11,6 +11,7 @@ import (
 )
 
 type IMook interface {
+	Init(*plugin.Parameters) error
 	GetName() string
 	GetAttestationScheme() string
 	GetSupportedMediaTypes() map[string][]string
@@ -19,6 +20,22 @@ type IMook interface {
 
 type MookRPCClient struct {
 	client *rpc.Client
+}
+
+func (o *MookRPCClient) Init(params *plugin.Parameters) error {
+	var (
+		unused any
+		args []byte
+		err error
+	)
+
+	if params != nil {
+		if args, err = params.MarshalJSON(); err != nil {
+			return err
+		}
+	}
+
+	return o.client.Call("Plugin.Init", args, &unused)
 }
 
 func (o *MookRPCClient) GetName() string {
@@ -88,6 +105,21 @@ func (o *MookRPCClient) Shoot() string {
 
 type MookRPCServer struct {
 	Impl IMook
+}
+
+func (o *MookRPCServer) Init(args []byte, resp *any) error {
+	var params *plugin.Parameters
+	var err error
+
+	if args == nil {
+		params = plugin.NewParameters()
+	} else {
+		if params, err = plugin.ParametersFromJSON(args); err != nil {
+			return err
+		}
+	}
+
+	return o.Impl.Init(params)
 }
 
 func (o *MookRPCServer) GetName(args any, resp *string) error {

--- a/plugin/test/powercell/powercell.go
+++ b/plugin/test/powercell/powercell.go
@@ -10,6 +10,10 @@ import (
 type PowerCell struct {
 }
 
+func (o PowerCell) Init(*plugin.Parameters) error {
+	return nil
+}
+
 func (o PowerCell) GetName() string {
 	return "power cell"
 }

--- a/plugin/test/redshirt/redshirt.go
+++ b/plugin/test/redshirt/redshirt.go
@@ -3,11 +3,20 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/veraison/services/plugin"
 	"github.com/veraison/services/plugin/test"
 )
 
 type RedShirt struct {
+	sound string
+}
+
+func (o *RedShirt) Init(params *plugin.Parameters) error {
+	var err error
+	o.sound, err = params.GetString("sound")
+	return err
 }
 
 func (o RedShirt) GetName() string {
@@ -23,7 +32,7 @@ func (o RedShirt) GetSupportedMediaTypes() map[string][]string {
 }
 
 func (o RedShirt) Shoot() string {
-	return `phaser goes "zap"`
+	return fmt.Sprintf("phaser goes %q", o.sound)
 }
 
 func main() {

--- a/plugin/test/trooper/trooper.go
+++ b/plugin/test/trooper/trooper.go
@@ -3,15 +3,25 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/veraison/services/plugin"
 	"github.com/veraison/services/plugin/test"
 )
 
 type ImperialTrooper struct {
+	sound string
+}
+
+func (o *ImperialTrooper) Init(params *plugin.Parameters) error {
+	var err error
+
+	o.sound, err = params.GetString("sound")
+	return err
 }
 
 func (o ImperialTrooper) GetName() string {
-	return "Galactic Imperial trooper"
+	return "Galactic Imperial Trooper"
 }
 
 func (o ImperialTrooper) GetAttestationScheme() string {
@@ -23,7 +33,7 @@ func (o ImperialTrooper) GetSupportedMediaTypes() map[string][]string {
 }
 
 func (o ImperialTrooper) Shoot() string {
-	return `blaster goes "pew, pew"`
+	return fmt.Sprintf("blaster goes %q", o.sound)
 }
 
 func main() {

--- a/scheme/README.md
+++ b/scheme/README.md
@@ -202,6 +202,12 @@ func main() {
 (Note that `ISchemeHandler` embeds `ISchemeImplementation`, so you would still
 need to implement it.)
 
+> [!NOTE]
+> When implementing `IPluggable.GetName()` as part of a full `ISchemeHandler`
+> implementation, it is strongly recommended to use
+> `handler.PluginNameFromScheme()` as configuration processing relies on the
+> plugin name being derived from the scheme name using that function.
+
 ### Call order
 
 During evidence appraisal, `ISchemeHandler` methods will be invoked in the
@@ -293,6 +299,16 @@ individual attestation schemes.
       an error when trying to add them.
 
 [draft-ietf-rats-corim-09]: https://datatracker.ietf.org/doc/draft-ietf-rats-corim/
+
+## Initializing and configuring schemes
+
+Custom one-time initialization may be provided by implementing the (optional)
+`Init(*plugin.Parmeters) error` method on your scheme implementation. Please
+see [plugin documentation](/plugin/README.md) for details.
+
+Parameter values can be specified namespaced under the (case insensitive)
+scheme name under the top-level `scheme` entry in VTS configuration. Please see
+[VTS service documentation](/vts/cmd/vts-service/README.md) for details.
 
 ## Debugging
 

--- a/scheme/amd-kds-coserv/coserv_handler.go
+++ b/scheme/amd-kds-coserv/coserv_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/veraison/corim/comid"
 	"github.com/veraison/corim/coserv"
+	"github.com/veraison/services/plugin"
 )
 
 type CoservProxyHandler struct{}
@@ -47,6 +48,10 @@ func getVcekForInstance(instance *coserv.StatefulInstance) ([]byte, error) {
 	}
 
 	return certBytes, nil
+}
+
+func (s CoservProxyHandler) Init(*plugin.Parameters) error {
+	return nil
 }
 
 func (s CoservProxyHandler) GetName() string {

--- a/scheme/nvidia-coserv/coserv_handler.go
+++ b/scheme/nvidia-coserv/coserv_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/veraison/corim/comid"
 	"github.com/veraison/corim/corim"
 	"github.com/veraison/corim/coserv"
+	"github.com/veraison/services/plugin"
 )
 
 // ----- JSON Helper Types -----
@@ -35,6 +36,10 @@ type CoservProxyHandler struct{}
 var (
 	dummyAuthority = []byte{0xab, 0xcd, 0xef}
 )
+
+func (s CoservProxyHandler) Init(*plugin.Parameters) error {
+	return nil
+}
 
 func (s CoservProxyHandler) GetName() string {
 	return "nvidia-coserv-proxy-handler"

--- a/vts/cmd/vts-service/README.md
+++ b/vts/cmd/vts-service/README.md
@@ -11,6 +11,7 @@ configuration:
 - `vts` (optional): Veraison Trusted Services backend configuration. See [trustedservices config](/vts/trustedservices/README.md#Configuration).
 - `logging` (optional): Logging configuration. See [logging config](/vts/log/README.md#Configuration).
 - `ear-signer`: Attestation Result signing configuration. See [signer config](/vts/ear-signer/README.md#Configuration).
+- `scheme` (optional): Scheme-specific configuration. See below.
 
 ### `plugin` configuration
 
@@ -29,6 +30,31 @@ The following directives are currently supported:
 #### `go-plugin` backend configuration
 
 - `dir`: path to the directory that will be scanned for plugin executables.
+
+#### `scheme` configuration
+
+`scheme` must be a map of (case insensitive) scheme names to configuration
+entries for those schemes. A configuration entry is a map of parameter names to
+corresponding parameter values. For example:
+
+```yaml
+scheme:
+  my_scheme_name:
+    foo: 1
+    bar: "baz"
+```
+
+Parameter values must be either strings, integers or booleans. Bytes values are
+also supported as either raw base64-encoded strings, `my_param: "3q2+7w=="`, or
+as YAML `!!binary` directives, `my_param: !!binary "3q2+7w=="`.
+
+Valid parameter names, and corresponding expected value types, are
+scheme-specific. Please refer to scheme documentation if it exists, otherwise
+assume that no parameters are expected (which is the case for most existing
+schemes).
+
+Any `scheme` sub-entry that doesn't correspond to a known scheme name will be
+ignored.
 
 ### Config files
 

--- a/vts/cmd/vts-service/config.yaml
+++ b/vts/cmd/vts-service/config.yaml
@@ -32,3 +32,8 @@ coserv-signer:
   key: ./skey.jwk
 logging:
   level: debug
+# Scheme configuration Example
+# (note: none of the current schemes expect any configuration)
+#scheme:
+  #ARM_CCA:
+    #foo: bar

--- a/vts/cmd/vts-service/main.go
+++ b/vts/cmd/vts-service/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	subs, err := config.GetSubs(v, "store", "po-store",
-		"*po-agent", "plugin", "*vts", "ear-signer", "*coserv-signer", "*logging")
+		"*po-agent", "plugin", "*vts", "ear-signer", "*coserv-signer", "*logging", "*scheme")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -63,6 +63,13 @@ func main() {
 	var schemePluginManager plugin.IManager[handler.ISchemeHandler]
 	var coservProxyPluginManager plugin.IManager[handler.ICoservProxyHandler]
 
+	log.Debug("loading scheme configuration")
+	pluginConfig, err := plugin.ParametersMapFromViper(subs["scheme"], handler.PluginNameFromScheme)
+	if err != nil {
+		log.Fatalf("could not load scheme config: %v", err)
+	}
+
+	log.Debug("loading scheme plugins")
 	psubs, err := config.GetSubs(subs["plugin"], "*go-plugin", "*builtin")
 	if err != nil {
 		log.Fatalf("could not get subs: %v", err)
@@ -72,6 +79,7 @@ func main() {
 	case "plugins":
 		loader, err := plugin.CreateGoPluginLoader(
 			psubs["go-plugin"].AllSettings(),
+			pluginConfig,
 			log.Named("plugin"))
 		if err != nil {
 			log.Fatalf("could not create plugin loader: %v", err)
@@ -96,6 +104,7 @@ func main() {
 	case "builtin":
 		loader, err := builtin.CreateBuiltinLoader(
 			psubs["builtin"].AllSettings(),
+			pluginConfig,
 			log.Named("builtin"))
 		if err != nil {
 			log.Fatalf("could not create builtin loader: %v", err)


### PR DESCRIPTION
Add an `Init()` method to `IPluggable`. This gets invoked immediately after a plugin is first loaded, giving opportunity for early one-time initialization. This method takes a `Parameters` object that contain configuration for the plugin.

`SchemeImplementationWrapper` has been updated to provide a default implementation, so implementing Init() is optional for attestation schemes.

Also, update the `lint` Makefile target to download and use a local version of `golangci-lint` to avoid possible compatibility issues with the system-installed version.