### PR TITLE
fix(scheme): comment TODO import in example

### DIFF
--- a/scheme/example/plugin/main.go
+++ b/scheme/example/plugin/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"github.com/veraison/services/handler"
 	"github.com/veraison/services/plugin"
-	scheme "github.com/veraison/services/scheme/<TODO>"
+	//scheme "github.com/veraison/services/scheme/<TODO>"
 )
 
 func main() {


### PR DESCRIPTION
While excluded form the build, the import causes issues when running "go mod tidy" with go version prior to 1.25.

Addresses https://github.com/veraison/services/issues/410