### PR TITLE
fix(plugin): fix Set() with float64

### DIFF
--- a/plugin/parameters.go
+++ b/plugin/parameters.go
@@ -178,7 +178,14 @@ func (o *Parameters) Set(key string, value any) error {
 	case int:
 		o.set(key, int64(t))
 	case float64:
-		if t < float64(math.MinInt64) || t > float64(math.MaxInt64) {
+		// note: due to limited precision, float(9223372036854775807)
+		// is 9223372036854775808.0, so we're using >= rather than >
+		// here. 
+		// This means that, in practice, the highest float64
+		// convertable to int64 is 9223372036854774784.0
+		// ((2^(63-52))/2), as anything above that would round up to
+		// 9223372036854775808.0.
+		if t < float64(math.MinInt64) || t >= float64(math.MaxInt64) {
 			return fmt.Errorf("%w for %q: out of int64 range: %v", ErrInvalid, key, t)
 		}
 


### PR DESCRIPTION
Correct the boundary condition for float64 value fitting into an int64 from "> float64(MaxInt64)" to ">= float64(MaxInt64)" As float64(MaxInt64) rounds to 9223372036854775808.0.

Addresses https://github.com/veraison/services/issues/414