### PR TITLE
Update to latest `corim-store` plus fixes

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.25"
+        go-version: "1.26"
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install mockgen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.25"
+        go-version: "1.26"
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install mockgen

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.25"
+        go-version: "1.26"
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install mockgen

--- a/.github/workflows/time-package.yml
+++ b/.github/workflows/time-package.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: false
       - name: Checkout code
         uses: actions/checkout@v4

--- a/deployments/docker/src/builder.docker
+++ b/deployments/docker/src/builder.docker
@@ -1,6 +1,6 @@
-# Go version that will be used to build the project. Due to the use of generics
-# within the project, it must be at least 1.25.
-ARG GO_VERSION=1.25
+# Go version that will be used to build the project. Due to dependencies, it
+# must be at least 1.26.
+ARG GO_VERSION=1.26
 
 FROM golang:${GO_VERSION} AS veraison-builder
 
@@ -63,8 +63,8 @@ RUN go mod download &&\
     go install github.com/veraison/cocli@v1.0.0-alpha0.0.20260313151307-405ce39d50b6 &&\
     go install github.com/veraison/evcli/v2@1685bf5 &&\
     go install github.com/veraison/pocli@v0.2.0 &&\
-    go install github.com/go-delve/delve/cmd/dlv@v1.24.0 &&\
-    go install github.com/veraison/corim-store/cmd/corim-store@9e4ba68b
+    go install github.com/go-delve/delve/cmd/dlv@v1.26.0 &&\
+    go install github.com/veraison/corim-store/cmd/corim-store@bba8b06e05f6
 
 ADD --chown=builder:builder builder-dispatcher .
 ADD --chown=builder:builder builder-bashrc /home/builder/.bashrc

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veraison/services
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
@@ -40,8 +40,8 @@ require (
 	github.com/tbaehler/gin-keycloak v1.6.1
 	github.com/veraison/ccatoken v1.3.2-0.20250512122414-b26aba0635c4
 	github.com/veraison/cmw v0.2.0
-	github.com/veraison/corim v1.1.3-0.20260309101151-2fa49d7c02e3
-	github.com/veraison/corim-store v0.0.0-20260220100808-e966b3eab910
+	github.com/veraison/corim v1.1.3-0.20260430132037-b8653a7359da
+	github.com/veraison/corim-store v0.1.0
 	github.com/veraison/dice v0.0.1
 	github.com/veraison/ear v1.1.4-0.20260213122616-3034258cda59
 	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
@@ -55,8 +55,6 @@ require (
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/go-jose/go-jose.v2 v2.6.3
 )
-
-require go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
@@ -148,6 +146,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/uptrace/bun v1.2.16 // indirect
+	github.com/uptrace/bun/dbfixture v1.2.15 // indirect
 	github.com/uptrace/bun/dialect/mysqldialect v1.2.16 // indirect
 	github.com/uptrace/bun/dialect/pgdialect v1.2.16 // indirect
 	github.com/uptrace/bun/dialect/sqlitedialect v1.2.16 // indirect
@@ -163,6 +162,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1240,6 +1240,8 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/uptrace/bun v1.2.16 h1:QlObi6ZIK5Ao7kAALnh91HWYNZUBbVwye52fmlQM9kc=
 github.com/uptrace/bun v1.2.16/go.mod h1:jMoNg2n56ckaawi/O/J92BHaECmrz6IRjuMWqlMaMTM=
+github.com/uptrace/bun/dbfixture v1.2.15 h1:0wncXVJ7L6iYIukWe7WtCpTIxKc3Z3vFX5tAFqV674c=
+github.com/uptrace/bun/dbfixture v1.2.15/go.mod h1:vCAi8ESyYHcjFZNTcalwNHI3KYl9TC4CtzL26FsulkQ=
 github.com/uptrace/bun/dialect/mysqldialect v1.2.16 h1:ok06dAS094cEKvKg38SVAnXMroNHNaM5ZtpRkPE/Oz0=
 github.com/uptrace/bun/dialect/mysqldialect v1.2.16/go.mod h1:fjbFYeJZCK8z0m0ACvdgs+dbFdDIaLYWDr+jvaPLedQ=
 github.com/uptrace/bun/dialect/pgdialect v1.2.16 h1:KFNZ0LxAyczKNfK/IJWMyaleO6eI9/Z5tUv3DE1NVL4=
@@ -1256,10 +1258,10 @@ github.com/veraison/ccatoken v1.3.2-0.20250512122414-b26aba0635c4 h1:t2GQueIc1Sr
 github.com/veraison/ccatoken v1.3.2-0.20250512122414-b26aba0635c4/go.mod h1:vMqdbW4H/8A3oT+24qssuIK3Aefy06XqzTELGg+gWAg=
 github.com/veraison/cmw v0.2.0 h1:BWEvwZnD4nn5osq6XwQpTRcGxwV+Su4t6ytdAbVXAJY=
 github.com/veraison/cmw v0.2.0/go.mod h1:OiYKk1t6/Fmmg30ZpSMzi4nKr5kt3374sNTkgxC5BDs=
-github.com/veraison/corim v1.1.3-0.20260309101151-2fa49d7c02e3 h1:yFF+d5ekY8g1nTAuV3lEvVI4dGdQMcoYp8blegIrrSQ=
-github.com/veraison/corim v1.1.3-0.20260309101151-2fa49d7c02e3/go.mod h1:96PQ0lk+O9bzutKTDz66G2DaARYUp1BeR06EYwEwSH0=
-github.com/veraison/corim-store v0.0.0-20260220100808-e966b3eab910 h1:hg09D27B9qkrN6zFQEs6wEG0qiTk451ExGMnSAq2tXY=
-github.com/veraison/corim-store v0.0.0-20260220100808-e966b3eab910/go.mod h1:/SqPJwSHexrxsNtiAJ/JqNgvC6+yihOyRlrTJO+0GnY=
+github.com/veraison/corim v1.1.3-0.20260430132037-b8653a7359da h1:HY6eZqJXjTIs0jQ3W47Aj+AzMitmR/Jjx5lld58yE48=
+github.com/veraison/corim v1.1.3-0.20260430132037-b8653a7359da/go.mod h1:tB4fHouhmQBL8JIt8TkYviA/xmmUBAWruwrR5YBHvn0=
+github.com/veraison/corim-store v0.1.0 h1:zu7kYtvnle01PHz6UKB2SfVypcZV6bWPHpDBBvxkwLk=
+github.com/veraison/corim-store v0.1.0/go.mod h1:eU8AECLQL+GQpEYksKDlom3HHXWzo/M6qR2gHXjjnR4=
 github.com/veraison/dice v0.0.1 h1:dOm7ByDN/r4WlDsGkEUXzdPMXgTvAPTAksQ8+BwBrD4=
 github.com/veraison/dice v0.0.1/go.mod h1:QPMLc5LVMj08VZ+HNMYk4XxWoVYGAUBVm8Rd5V1hzxs=
 github.com/veraison/ear v1.1.4-0.20260213122616-3034258cda59 h1:tynt7VXUc7uVAsN3RyWySaAJZpdQv0Eyru+7Wgwi72s=

--- a/integration-tests/data/endorsements/corim-psa-full.json
+++ b/integration-tests/data/endorsements/corim-psa-full.json
@@ -9,7 +9,7 @@
   "profile": "tag:arm.com,2025:psa#1.0.0",
   "validity": {
     "not-before": "2021-12-31T00:00:00Z",
-    "not-after": "2025-12-31T00:00:00Z"
+    "not-after": "2045-12-31T00:00:00Z"
   },
   "entities": [
     {

--- a/integration-tests/data/results/cca.good.json
+++ b/integration-tests/data/results/cca.good.json
@@ -51,10 +51,10 @@
   },
   "CCA_REALM": {
     "ear.appraisal-policy-id": "policy:ARM_CCA",
-    "ear.status": "warning",
+    "ear.status": "affirming",
     "ear.trustworthiness-vector": {
       "configuration": 0,
-      "executables": 33,
+      "executables": 2,
       "file-system": 0,
       "hardware": 0,
       "instance-identity": 2,

--- a/integration-tests/data/results/cca.verify-challenge.json
+++ b/integration-tests/data/results/cca.verify-challenge.json
@@ -49,10 +49,10 @@
     }
   },
   "CCA_REALM": {
-    "ear.status": "warning",
+    "ear.status": "affirming",
     "ear.trustworthiness-vector": {
       "configuration": 0,
-      "executables": 33,
+      "executables": 2,
       "file-system": 0,
       "hardware": 0,
       "instance-identity": 2,

--- a/scheme/arm-cca/scheme.go
+++ b/scheme/arm-cca/scheme.go
@@ -9,8 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/veraison/ccatoken"
 	"github.com/veraison/ccatoken/platform"
@@ -18,12 +16,15 @@ import (
 	"github.com/veraison/corim/comid"
 	"github.com/veraison/corim/profiles/cca"
 	"github.com/veraison/ear"
+	"github.com/veraison/psatoken"
 	"github.com/veraison/services/handler"
 	"github.com/veraison/services/log"
 	"github.com/veraison/services/scheme/common"
 	"github.com/veraison/services/vts/appraisal"
 	"go.uber.org/zap"
 )
+
+const NUM_REMS = 4
 
 var Descriptor = handler.SchemeDescriptor{
 	Name:         "ARM_CCA",
@@ -113,7 +114,9 @@ func (o *Implementation) GetReferenceValueIDs(
 			Class: trustAnchors[0].Environment.Class,
 		},
 		{
-			Instance: comid.MustNewBytesInstance(rimValue),
+			Class: &comid.Class{
+				ClassID: comid.MustNewBytesClassID(rimValue),
+			},
 		},
 	}, nil
 }
@@ -320,57 +323,71 @@ func AppraiseRealm(
 	appraisal.TrustVector.InstanceIdentity = ear.TrustworthyInstanceClaim
 	appraisal.TrustVector.Executables = ear.UnrecognizedRuntimeClaim
 
+	logger.Debug("collecting realm reference values...")
 	referenceValues := make([]realmReference, 0, len(endorsements))
 	for _, triple := range endorsements {
-		// unset Instance indicates platform endorsements
-		if triple.Environment.Instance == nil {
-			continue
+		refVal := realmReference{
+			ExtensibleMeasurements: make([][]byte, NUM_REMS),
 		}
 
 		for _, measurement := range triple.Measurements.Values {
-			refVal := realmReference{}
+			mkey, err := readMeasurementKey(&measurement)
+			if err != nil {
+				return err
+			}
 
-			if measurement.Val.RawValue != nil {
+			switch mkey {
+			case cca.CCARealmInitialMeasurementMkey:
+				digest, err := readMeasurementDigestBytes(&measurement)
+				if err != nil {
+					return fmt.Errorf("%s: %w", cca.CCARealmInitialMeasurementMkey, err)
+				}
+				refVal.InitialMeasurement = digest
+			case cca.CCARealmExtendedMeasurement0Mkey:
+				digest, err := readMeasurementDigestBytes(&measurement)
+				if err != nil {
+					return fmt.Errorf("%s: %w", cca.CCARealmExtendedMeasurement0Mkey, err)
+				}
+				refVal.ExtensibleMeasurements[0] = digest
+			case cca.CCARealmExtendedMeasurement1Mkey:
+				digest, err := readMeasurementDigestBytes(&measurement)
+				if err != nil {
+					return fmt.Errorf("%s: %w", cca.CCARealmExtendedMeasurement1Mkey, err)
+				}
+				refVal.ExtensibleMeasurements[1] = digest
+			case cca.CCARealmExtendedMeasurement2Mkey:
+				digest, err := readMeasurementDigestBytes(&measurement)
+				if err != nil {
+					return fmt.Errorf("%s: %w", cca.CCARealmExtendedMeasurement2Mkey, err)
+				}
+				refVal.ExtensibleMeasurements[2] = digest
+			case cca.CCARealmExtendedMeasurement3Mkey:
+				digest, err := readMeasurementDigestBytes(&measurement)
+				if err != nil {
+					return fmt.Errorf("%s: %w", cca.CCARealmExtendedMeasurement3Mkey, err)
+				}
+				refVal.ExtensibleMeasurements[3] = digest
+			case cca.CCARealmPersonalizationMkey:
+				if measurement.Val.RawValue == nil {
+					return fmt.Errorf("raw-value not set for %s",
+						cca.CCARealmPersonalizationMkey)
+				}
+
 				refVal.PersonalizationValue, err = measurement.Val.RawValue.GetBytes()
 				if err != nil {
-					return fmt.Errorf("personalization value: %w", err)
+					return fmt.Errorf("%s: %w", cca.CCARealmPersonalizationMkey, err)
 				}
+			default:
+				logger.Debugw("skipping non-realm measurement", "mkey", mkey)
 			}
 
-			if measurement.Val.IntegrityRegisters == nil {
-				return errors.New("integrity registers not set in realm reference")
-			}
+		}
 
-			numREMs := len(measurement.Val.IntegrityRegisters.IndexMap) - 1
-			refVal.ExtensibleMeasurements = make([][]byte, numREMs)
-
-			for key, digests := range measurement.Val.IntegrityRegisters.IndexMap {
-				dLen := len(digests)
-				if dLen != 1 {
-					return fmt.Errorf("expected 1 digest for integ. reg.; found %d", dLen)
-				}
-
-				keyText, ok := key.(string)
-				if !ok {
-					return fmt.Errorf("non-string integ. reg. key: %v", key)
-				}
-
-				if keyText == "rim" {
-					refVal.InitialMeasurement = digests[0].HashValue
-				} else {
-					idxText := strings.Replace(keyText, "rem", "", 1)
-					idx, err := strconv.Atoi(idxText)
-					if err != nil {
-						return fmt.Errorf("bad REM key: %s", keyText)
-					}
-
-					refVal.ExtensibleMeasurements[idx] = digests[0].HashValue
-				}
-			}
-
+		if refVal.InitialMeasurement != nil {
 			referenceValues = append(referenceValues, refVal)
 		}
 	}
+	logger.Debug("collected realm reference values", "values", referenceValues)
 
 	for _, refVal := range referenceValues {
 		if !bytes.Equal(refVal.InitialMeasurement, evidenceRIM) {
@@ -428,6 +445,37 @@ func convertToPlatformClaims(v any) (platform.IClaims, error) {
 	return platform.DecodeClaimsFromJSON(encoded)
 }
 
+func readMeasurementKey(measurement *comid.Measurement) (string, error) {
+	if measurement.Key == nil || !measurement.Key.IsSet() {
+		return "", errors.New(" measurement missing mkey")
+	}
+
+	if measurement.Key.Type() != comid.StringType {
+		return "", fmt.Errorf(
+			"measurement mkey must be string, got %s",
+			measurement.Key.Type(),
+		)
+	}
+
+	return measurement.Key.Value.String(), nil
+}
+
+func readMeasurementDigestBytes(measurement *comid.Measurement) ([]byte, error) {
+	if measurement.Val.Digests == nil {
+		return nil, errors.New("no digests in reference value measurement")
+	}
+
+	numDigests := len(*measurement.Val.Digests)
+	if numDigests != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly 1 digest in measurement; found %d",
+			numDigests,
+		)
+	}
+
+	return (*measurement.Val.Digests)[0].HashValue, nil
+}
+
 func matchPlatformClaimsToReferenceValues(
 	logger *zap.SugaredLogger,
 	claims platform.IClaims,
@@ -436,30 +484,18 @@ func matchPlatformClaimsToReferenceValues(
 	var err error
 	var referenceConfigValue []byte
 
+	logger.Debug("building platform reference values map...")
 	referenceValues := make(map[string][2]string)
 	for _, triple := range endorsements {
-		// set Instance indicates realm endorsements
-		if triple.Environment.Instance != nil {
-			continue
-		}
-
 		for _, measurement := range triple.Measurements.Values {
-			if measurement.Key == nil || !measurement.Key.IsSet() {
-				return false, false, errors.New("platform reference value measurement missing mkey")
+			mkey, err := readMeasurementKey(&measurement)
+			if err != nil {
+				return false, false, err
 			}
-
-			if measurement.Key.Type() != comid.StringType {
-				return false, false, fmt.Errorf(
-					"platform reference value measurement mkey must be string, got %s",
-					measurement.Key.Type(),
-				)
-			}
-
-			mkey := measurement.Key.Value.String()
 
 			// Check if this is a platform config measurement.
-			if mkey == cca.CCAPlatformConfigMkey {
-
+			switch mkey {
+			case cca.CCAPlatformConfigMkey:
 				if measurement.Val.RawValue == nil {
 					return false, false,
 						errors.New("no raw value in platform config measurement")
@@ -471,42 +507,30 @@ func matchPlatformClaimsToReferenceValues(
 				}
 
 				continue
-			}
+			case cca.CCASoftwareComponentMkey:
+				digest, err := readMeasurementDigestBytes(&measurement)
+				if err != nil {
+					return false, false, err
+				}
 
-			if mkey != "cca.software-component" {
-				return false, false, fmt.Errorf(
-					"invalid mkey %q in platform reference value measurement",
-					mkey,
-				)
-			}
+				encoded := base64.StdEncoding.EncodeToString(digest)
+				// Extract label (mtype) and version from measurement value
+				var label, version string
 
-			// Not a platform-config entry: this must be a platform software component.
-			if measurement.Val.Digests == nil {
-				return false, false, errors.New("no digests in reference value measurement")
-			}
+				if measurement.Val.Name != nil {
+					label = *measurement.Val.Name
+				}
+				if measurement.Val.Ver != nil {
+					version = measurement.Val.Ver.Version
+				}
 
-			numDigests := len(*measurement.Val.Digests)
-			if numDigests != 1 {
-				return false, false, fmt.Errorf(
-					"expected exactly 1 digest in measurement; found %d",
-					numDigests,
-				)
+				referenceValues[encoded] = [2]string{label, version}
+			default:
+				logger.Debugw("skipping non-platform measurement", "mkey", mkey)
 			}
-
-			encoded := base64.StdEncoding.EncodeToString((*measurement.Val.Digests)[0].HashValue)
-			// Extract label (mtype) and version from measurement value
-			var label, version string
-
-			if measurement.Val.Name != nil {
-				label = *measurement.Val.Name
-			}
-			if measurement.Val.Ver != nil {
-				version = measurement.Val.Ver.Version
-			}
-
-			referenceValues[encoded] = [2]string{label, version}
 		}
 	}
+	logger.Debugw("platform reference values", "map", referenceValues)
 
 	evidenceConfigValue, err := claims.GetConfig()
 	if err != nil {
@@ -539,7 +563,7 @@ func matchPlatformClaimsToReferenceValues(
 		}
 
 		mversion, err := swComp.GetVersion()
-		if err != nil {
+		if err != nil && !errors.Is(err, psatoken.ErrOptionalFieldMissing) {
 			return false, false, handler.BadEvidence(fmt.Errorf("S/W comp. %d version: %w", i, err))
 		}
 
@@ -571,7 +595,7 @@ func allMatch(lhs, rhs [][]byte) bool {
 	}
 
 	for i, lhsV := range lhs {
-		if !bytes.Equal(lhsV, rhs[i]) {
+		if len(lhsV) > 0 && !bytes.Equal(lhsV, rhs[i]) {
 			return false
 		}
 	}

--- a/vts/store/store.go
+++ b/vts/store/store.go
@@ -19,7 +19,14 @@ type Config struct {
 }
 
 func (o *Config) StoreConfig() *corimstore.Config {
-	ret := corimstore.NewConfig(o.DBMS, o.DSN, corimstore.OptionRequireLabel)
+	ret := corimstore.NewConfig(
+		o.DBMS,
+		o.DSN,
+		corimstore.OptionRequireLabel,
+		// Signatures of signed CoRIMs are verified as part of their
+		// initial processing, prior to adding them to the store.
+		corimstore.OptionInsecure,
+	)
 
 	if o.TraceSQL {
 		ret.WithOptions(corimstore.OptionTraceSQL)

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -277,8 +276,7 @@ func (o *GRPC) SubmitEndorsements(
 	}
 
 	label := fmt.Sprintf("%s/%s", DummyTenantID, handlerPlugin.GetAttestationScheme())
-	digest := o.Store.Digest(req.Data)
-	if err := o.Store.AddCoRIM(uc, digest, label, true); err != nil {
+	if err := o.Store.AddBytes(req.Data, label, true); err != nil {
 		return submitEndorsementErrorResponse(err), nil
 	}
 
@@ -632,68 +630,14 @@ func (o *GRPC) getEndorsementsFromStores(queryIn *proto.EndorsementQueryIn) ([]b
 		return nil, err
 	}
 
-	profile, err := query.Profile.Get()
+	fallbackAuthority, err := comid.NewCryptoKeyTaggedBytes([]byte("dummyauth"))
 	if err != nil {
 		return nil, err
 	}
 
-	// Look up a matching endorsement plugin
-	schemeHandler, err := o.SchemePluginManager.LookupByMediaType(
-		fmt.Sprintf(`application/rim+cbor; profile=%q`, profile))
-	if err != nil {
+	coservService := corimstore.NewCoSERVService(o.Store, fallbackAuthority)
+	if err := coservService.UpdateCoSERV(&query); err != nil {
 		return nil, err
-	}
-
-	scheme := schemeHandler.GetAttestationScheme()
-	label := fmt.Sprintf("%s/%s", DummyTenantID, scheme)
-
-	authority, err := comid.NewCryptoKeyTaggedBytes([]byte("dummyauth"))
-	if err != nil {
-		return nil, err
-	}
-
-	environments, err := querySelectorToEnvironments(&query.Query.EnvironmentSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	resultSet := coserv.NewResultSet()
-
-	// add (dummy, for now -- TODO) expiry
-	dummyExpiry := time.Now().Add(time.Hour * 1)
-	resultSet.SetExpiry(dummyExpiry)
-
-	switch query.Query.ArtifactType {
-	case coserv.ArtifactTypeTrustAnchors:
-		keyTriples, err := o.getKeyTriples(environments, label, false)
-		if err != nil && !errors.Is(err, corimstore.ErrNoMatch) {
-			return nil, err
-		}
-
-		for _, keyTriple := range keyTriples {
-			resultSet.AddAttestationKeys(coserv.AKQuad{
-				Authorities: comid.NewCryptoKeys().Add(authority),
-				AKTriple:    keyTriple,
-			})
-		}
-	case coserv.ArtifactTypeReferenceValues:
-		valueTriples, err := o.getValueTriples(environments, label, false)
-		if err != nil && !errors.Is(err, corimstore.ErrNoMatch) {
-			return nil, err
-		}
-
-		for _, valueTriple := range valueTriples {
-			resultSet.AddReferenceValues(coserv.RefValQuad{
-				Authorities: comid.NewCryptoKeys().Add(authority),
-				RVTriple:    valueTriple,
-			})
-		}
-	default:
-		return nil, errors.New("only reference value and trust anchors are supported at present")
-	}
-
-	if err := query.AddResults(*resultSet); err != nil {
-		return nil, fmt.Errorf("could not add result set to query: %w", err)
 	}
 
 	return query.ToCBOR()
@@ -898,46 +842,4 @@ func SerializeCertPEMBytes(certPEMs [][]byte) ([]byte, error) {
 	}
 
 	return allPEM.Bytes(), nil
-}
-
-func querySelectorToEnvironments(selector *coserv.EnvironmentSelector) ([]*comid.Environment, error) {
-	var ret []*comid.Environment
-
-	if selector.Classes != nil {
-		for _, statefulClass := range *selector.Classes {
-			if statefulClass.Measurements != nil {
-				return nil, ErrMeasurementsNotSupported
-			}
-
-			ret = append(ret, &comid.Environment{
-				Class: statefulClass.Class,
-			})
-		}
-	}
-
-	if selector.Instances != nil {
-		for _, statefulInstance := range *selector.Instances {
-			if statefulInstance.Measurements != nil {
-				return nil, ErrMeasurementsNotSupported
-			}
-
-			ret = append(ret, &comid.Environment{
-				Instance: statefulInstance.Instance,
-			})
-		}
-	}
-
-	if selector.Groups != nil {
-		for _, statefulGroup := range *selector.Groups {
-			if statefulGroup.Measurements != nil {
-				return nil, ErrMeasurementsNotSupported
-			}
-
-			ret = append(ret, &comid.Environment{
-				Group: statefulGroup.Group,
-			})
-		}
-	}
-
-	return ret, nil
 }


### PR DESCRIPTION
- Update to the latest `corim-store`, switching to it to handle CoSERV
- Fix CCA attestation handling of updated endorsement formats