### PR TITLE
fix(sevsnp): add report integrity validation back

### DIFF
--- a/scheme/sevsnp/scheme.go
+++ b/scheme/sevsnp/scheme.go
@@ -13,10 +13,13 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/google/go-sev-guest/abi"
 	"github.com/google/go-sev-guest/kds"
 	"github.com/google/go-sev-guest/proto/sevsnp"
+	"github.com/google/go-sev-guest/verify"
+	"github.com/google/go-sev-guest/verify/trust"
 	sevsnpParser "github.com/jraman567/go-gen-ref/cmd/sevsnp"
 	"github.com/veraison/cmw"
 	"github.com/veraison/corim/comid"
@@ -38,11 +41,19 @@ var (
 	ErrNoASK                  = errors.New("missing ASK certificate in evidence")
 	ErrNoVEK                  = errors.New("evidence must supply VLEK or VCEK")
 	ErrTAMismatch             = errors.New("evidence Trust Anchor (ARK) doesn't match the provisioned one")
+	ErrNoVCEK                 = errors.New("VCEK is missing")
+	ErrNoVLEK                 = errors.New("VLEK is missing")
+	ErrBadSigningKey          = errors.New("bad signing key in attestation report")
 
 	EndorsementMediaTypeRV   = `application/corim-unsigned+cbor; profile="tag:amd.com,2024:snp-corim-profile"`
 	EvidenceMediaTypeRATSd   = `application/eat+cwt; eat_profile="tag:github.com,2025:veraison/ratsd/cmw"`
 	EvidenceMediaTypeTSMCbor = "application/vnd.veraison.tsm-report+cbor"
 	EvidenceMediaTypeTSMJson = "application/vnd.veraison.tsm-report+json"
+)
+
+const (
+	ReportSigningKeyVcek = 0
+	ReportSigningKeyVlek = 1
 )
 
 const (
@@ -201,7 +212,7 @@ func (o *Implementation) ValidateEvidenceIntegrity(
 		return err
 	}
 
-	return nil
+	return validateReportIntegrity(tsm, certChain)
 }
 
 func (o *Implementation) AppraiseClaims(
@@ -662,4 +673,68 @@ func compareMeasurements(logger *zap.SugaredLogger, refM comid.Measurement, evM 
 	}
 
 	return true
+}
+
+func validateReportIntegrity(tsm *tokens.TSMReport, certChain *sevsnp.CertificateChain) error {
+	var (
+		ark, ask, vcek, vlek []byte
+		attestation          sevsnp.Attestation
+	)
+
+	// options: options to use when verifying SEV-SNP evidence
+	//          not feasible to enable certificate fetching and
+	//          checking revocations as AMD KDS rate-limits requests
+	options := verify.Options{
+		Getter:              trust.DefaultHTTPSGetter(),
+		Now:                 time.Now(),
+		DisableCertFetching: true,
+		CheckRevocations:    false,
+	}
+
+	protoReport, err := abi.ReportToProto(tsm.OutBlob)
+	if err != nil {
+		return err
+	}
+	attestation.Report = protoReport
+
+	if ark, err = readCert(certChain.GetArkCert()); err != nil {
+		return fmt.Errorf("can't read ARK to validate cert chain: %w", err)
+	}
+
+	if ask, err = readCert(certChain.GetAskCert()); err != nil {
+		return fmt.Errorf("can't read ASK to validate cert chain: %w", err)
+	}
+
+	signerInfo, err := abi.ParseSignerInfo(protoReport.GetSignerInfo())
+	if err != nil {
+		return err
+	}
+
+	switch signerInfo.SigningKey {
+	case ReportSigningKeyVlek:
+		if len(certChain.GetVlekCert()) == 0 {
+			return ErrNoVLEK
+		}
+		if vlek, err = readCert(certChain.GetVlekCert()); err != nil {
+			return fmt.Errorf("can't read VLEK to validate cert chain: %w", err)
+		}
+		attestation.CertificateChain = &sevsnp.CertificateChain{VlekCert: vlek, AskCert: ask, ArkCert: ark}
+	case ReportSigningKeyVcek:
+		if len(certChain.GetVcekCert()) == 0 {
+			return ErrNoVCEK
+		}
+		if vcek, err = readCert(certChain.GetVcekCert()); err != nil {
+			return fmt.Errorf("can't read VCEK to validate cert chain: %w", err)
+		}
+		attestation.CertificateChain = &sevsnp.CertificateChain{VcekCert: vcek, AskCert: ask, ArkCert: ark}
+	default:
+		return ErrBadSigningKey
+	}
+
+	err = verify.SnpAttestation(&attestation, &options)
+	if err != nil {
+		return handler.BadEvidence(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
We need to validate the SEV-SNP attestation report's integrity before verifying the claims in the report. Add validateReportIntegrity() which does this.

This was originally part of PR 333:
https://github.com/veraison/services/pull/333. But it appears to have been accidentally dropped during the CoRIM store refactor: https://github.com/veraison/services/pull/383