### PR TITLE
fix: ignore nvidia scheme on systems without nvat.h

### DIFF
--- a/builtin/schemes.go
+++ b/builtin/schemes.go
@@ -8,7 +8,6 @@ import (
 
 	scheme9 "github.com/veraison/services/scheme/amd-kds-coserv"
 	scheme3 "github.com/veraison/services/scheme/arm-cca"
-	scheme10 "github.com/veraison/services/scheme/nvidia"
 	scheme8 "github.com/veraison/services/scheme/nvidia-coserv"
 	scheme1 "github.com/veraison/services/scheme/parsec-cca"
 	scheme5 "github.com/veraison/services/scheme/parsec-tpm"
@@ -26,7 +25,6 @@ var plugins = []plugin.IPluggable{
 	handler.MustNewSchemeImplementationWrapper(scheme5.Descriptor, scheme5.NewImplementation()),
 	handler.MustNewSchemeImplementationWrapper(scheme6.Descriptor, scheme6.NewImplementation()),
 	handler.MustNewSchemeImplementationWrapper(scheme7.Descriptor, scheme7.NewImplementation()),
-	handler.MustNewSchemeImplementationWrapper(scheme10.Descriptor, scheme10.NewImplementation()),
 	&scheme8.CoservProxyHandler{},
 	&scheme9.CoservProxyHandler{},
 }

--- a/scheme/nvidia/Makefile
+++ b/scheme/nvidia/Makefile
@@ -1,5 +1,9 @@
 # Copyright 2026 Contributors to the Veraison project.
 # SPDX-License-Identifier: Apache-2.0
+THISDIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+CHECK := $(shell $(THISDIR)/check-nvat.sh; echo $$?)
+ifeq ($(CHECK),0)
+
 .DEFAULT_GOAL := test
 
 GOPKG := github.com/veraison/services/scheme/nvidia
@@ -12,3 +16,13 @@ include ../../mk/lint.mk
 include ../../mk/pkg.mk
 include ../../mk/subdir.mk
 include ../../mk/test.mk
+
+else
+
+all:
+test:
+lint:
+
+$(info skipping nvidia scheme; could not find nvat.h in the system)
+
+endif

--- a/scheme/nvidia/check-nvat.sh
+++ b/scheme/nvidia/check-nvat.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright 2026 Contributors to the Veraison project.
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ "$(type -p cc)" == "" ]]; then
+	echo "C compiler not installed"
+	exit 1
+fi
+
+if ! (echo -e '#include <nvat.h>\n' | cc -E -x c - >/dev/null 2>&1); then
+	echo "nvat.h not found"
+	exit 1
+fi
+
+

--- a/verification/api/challengeresponsesession.go
+++ b/verification/api/challengeresponsesession.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Contributors to the Veraison project.
+// Copyright 2022-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
 // The api package implements the REST API defined in


### PR DESCRIPTION
`nvidia` scheme is built against an external C library, which may or may
not be installed on host trying to build Veraison. To avoid requiring
everyone to worry about this, check whether the C library is already
installed, and stub-out make targets if it isn't. make will no longer
fail if the dependency is missing and will just generate a message
instead.

Since `nvidia` scheme is conditioned on this external dependency, remove
it from the built-in scheme list.