### PR TITLE
Fix building in CI and docker deployment

### DIFF
--- a/.github/actions/install-nvat-dev/action.yml
+++ b/.github/actions/install-nvat-dev/action.yml
@@ -7,9 +7,14 @@ runs:
       shell: bash
       run: |
         distro="ubuntu$(. /etc/os-release && printf '%s' "$VERSION_ID" | tr -d .)"
+        case "$(dpkg --print-architecture)" in
+            amd64) repo_arch=x86_64 ;;
+            arm64) repo_arch=sbsa ;;
+            *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;;
+        esac
         keyring="$RUNNER_TEMP/cuda-keyring.deb"
         curl --fail --location --silent --show-error \
-          "https://developer.download.nvidia.com/compute/cuda/repos/${distro}/x86_64/cuda-keyring_1.1-1_all.deb" \
+          "https://developer.download.nvidia.com/compute/cuda/repos/${distro}/${repo_arch}/cuda-keyring_1.1-1_all.deb" \
           --output "$keyring"
         sudo dpkg --install "$keyring"
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,11 @@ name: ci
 on: [push, pull_request]
 jobs:
   tests:
-    name: Test on ubuntu-latest
-    runs-on: ubuntu-latest
+    name: Test on ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     env:
       GO111MODULE: on
       CI_PIPELINE: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,10 @@ on: [push, pull_request]
 jobs:
   integration-tests:
     name: Run integration tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/deployments/docker/src/builder.docker
+++ b/deployments/docker/src/builder.docker
@@ -35,7 +35,12 @@ RUN apt-get update \
 	ca-certificates \
         wget \
     && distro="$(. /etc/os-release && printf '%s%s' "$ID" "$(printf '%s' "$VERSION_ID" | tr -d .)")" \
-    && wget --quiet "https://developer.download.nvidia.com/compute/cuda/repos/${distro}/x86_64/cuda-keyring_1.1-1_all.deb" \
+    && case "$(dpkg --print-architecture)" in \
+           amd64) repo_arch=x86_64 ;; \
+           arm64) repo_arch=sbsa ;; \
+           *) echo "unsupported architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+       esac \
+    && wget --quiet "https://developer.download.nvidia.com/compute/cuda/repos/${distro}/${repo_arch}/cuda-keyring_1.1-1_all.deb" \
     && dpkg --install cuda-keyring_1.1-1_all.deb \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --assume-yes --no-install-recommends libnvat-dev \


### PR DESCRIPTION
This adds the correct amd64 or arm64 NVIDIA repository.

~~The arm64 docker deployment is untested. @setrofim should we add building the docker deployment to the CI?~~ Run by integration tests.

Partly addresses: https://github.com/veraison/services/issues/442