### PR TITLE
build: add RPM release workflow

### DIFF
--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,8 +1,9 @@
-name: Build RPM release package
+name: Automatic RPM package creation based on the monthly tag
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - v0.0.**
 
 permissions:
   contents: read
@@ -15,12 +16,13 @@ jobs:
     env:
       GO111MODULE: on
       CI_PIPELINE: true
-      RELEASE_VERSION: ${{ github.event.release.tag_name }}
+      RELEASE_VERSION: ${{ github.ref_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -54,6 +56,6 @@ jobs:
       - name: Upload RPM
         uses: actions/upload-artifact@v4
         with:
-          name: veraison-services-rpm-${{ github.event.release.tag_name }}
+          name: veraison-services-rpm-${{ github.ref_name }}
           path: ~/rpmbuild/RPMS/**/*.rpm
           if-no-files-found: error

--- a/.github/workflows/release-rpm.yml
+++ b/.github/workflows/release-rpm.yml
@@ -1,0 +1,59 @@
+name: Build RPM release package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    name: Build RPM
+    runs-on: ubuntu-latest
+    container: fedora:42
+    env:
+      GO111MODULE: on
+      CI_PIPELINE: true
+      RELEASE_VERSION: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: false
+
+      - name: Install RPM build dependencies
+        run: |
+          dnf --assumeyes install \
+            gcc \
+            gettext \
+            git \
+            golang \
+            jose \
+            jq \
+            make \
+            openssl \
+            protobuf \
+            protobuf-compiler \
+            protobuf-devel \
+            rpm-build \
+            rpmdevtools \
+            sqlite
+
+      - name: Build RPM
+        run: |
+          export VERAISON_BUILD_VERSION="${RELEASE_VERSION#v}"
+          make rpm
+
+      - name: Upload RPM
+        uses: actions/upload-artifact@v4
+        with:
+          name: veraison-services-rpm-${{ github.event.release.tag_name }}
+          path: ~/rpmbuild/RPMS/**/*.rpm
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

- build an RPM whenever a GitHub Release is published
- upload the RPM as a release-versioned workflow artifact

## Testing

- YAML parsed successfully
- `git diff --check`