### PR TITLE
tpm-enacttrust: accept unpadded nonce encodings

### DIFF
--- a/scheme/tpm-enacttrust/test/cmd/gen-token/main.go
+++ b/scheme/tpm-enacttrust/test/cmd/gen-token/main.go
@@ -57,13 +57,25 @@ func readTokenDescription(path string) (*TokenDescription, error) {
 	return &desc, nil
 }
 
-// decodeNonce decodes a base64 nonce, accepting standard or URL-safe encoding
-// so it matches whatever the verification session used.
+// decodeNonce decodes a base64 nonce, accepting padded or unpadded standard
+// and URL-safe encodings so it matches whatever the verification session used.
 func decodeNonce(s string) ([]byte, error) {
-	if b, err := base64.StdEncoding.DecodeString(s); err == nil {
-		return b, nil
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
 	}
-	return base64.URLEncoding.DecodeString(s)
+
+	var err error
+	for _, encoding := range encodings {
+		var b []byte
+		if b, err = encoding.DecodeString(s); err == nil {
+			return b, nil
+		}
+	}
+
+	return nil, err
 }
 
 func readPrivateKey(path string) (*ecdsa.PrivateKey, error) {

--- a/scheme/tpm-enacttrust/test/cmd/gen-token/main_test.go
+++ b/scheme/tpm-enacttrust/test/cmd/gen-token/main_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDecodeNonce(t *testing.T) {
+	want := []byte{0xfb, 0xff}
+
+	tests := map[string]string{
+		"padded standard":   "+/8=",
+		"unpadded standard": "+/8",
+		"padded URL-safe":   "-_8=",
+		"unpadded URL-safe": "-_8",
+	}
+
+	for name, encoded := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := decodeNonce(encoded)
+			if err != nil {
+				t.Fatalf("decodeNonce(%q) returned an error: %v", encoded, err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Errorf("decodeNonce(%q) = %x, want %x", encoded, got, want)
+			}
+		})
+	}
+}
+
+func TestDecodeNonceRejectsInvalidEncoding(t *testing.T) {
+	if _, err := decodeNonce("not base64!"); err == nil {
+		t.Fatal("decodeNonce() accepted invalid base64")
+	}
+}


### PR DESCRIPTION
Hi!

This PR is to accept more encodings for the Nonce, as requested in [https://github.com/veraison/services/pull/432.](https://github.com/veraison/services/pull/432.)
Please note that I used agents to proceed (although iteration through encodings makes sense to me). 